### PR TITLE
Make the WP Mock TestCase class abstract

### DIFF
--- a/WP_Mock/Tools/TestCase.php
+++ b/WP_Mock/Tools/TestCase.php
@@ -9,7 +9,7 @@ use ReflectionMethod;
 use WP_Mock\Tools\Constraints\ExpectationsMet;
 use WP_Mock\Tools\Constraints\IsEqualHtml;
 
-class TestCase extends \PHPUnit_Framework_TestCase {
+abstract class TestCase extends \PHPUnit_Framework_TestCase {
 
 	protected $mockedStaticMethods = array();
 


### PR DESCRIPTION
This will prevent PHPUnit from thinking it should have tests associated with it.
