### PR TITLE
Workaround for HHVM not supporting case-insensitive constants

### DIFF
--- a/WP_Mock/API/constant-mocks.php
+++ b/WP_Mock/API/constant-mocks.php
@@ -33,10 +33,21 @@ if ( ! defined( 'EZSQL_VERSION' ) ) {
 }
 
 /**
+ * HHVM does not support case-insensitive constants.
+ * 
  * @since 0.71
+ * @see   http://hhvm.com/blog/3095/getting-wordpress-running-on-hhvm
  */
 if ( ! defined( 'OBJECT' ) ) {
-	define( 'OBJECT', 'OBJECT', true );
+	define( 'OBJECT', 'OBJECT' );
+}
+
+if ( ! defined( 'Object' ) ) {
+	define( 'Object', 'OBJECT' );
+}
+
+if ( ! defined( 'object' ) ) {
+	define( 'object', 'OBJECT' );
 }
 
 /**


### PR DESCRIPTION
First of all, great job, guys!

I'm automating my tests using Travis CI and ran into this issue when enabling tests under HHVM:

```
Case insensitive constant names are not supported in HipHop
/home/travis/build/goblindegook/Syllables/vendor/10up/wp_mock/WP_Mock/API/constant-mocks.php:39
/home/travis/build/goblindegook/Syllables/vendor/10up/wp_mock/WP_Mock.php:71
/home/travis/build/goblindegook/Syllables/vendor/10up/wp_mock/WP_Mock.php:101
/home/travis/build/goblindegook/Syllables/vendor/10up/wp_mock/WP_Mock/Tools/TestCase.php:37
```

Line 39 in `constant-mocks.php` tries to set the `OBJECT` constant in a case-insensitive manner:

``` php
define( 'OBJECT', 'OBJECT', true );
```

This patch removes the third `define()` argument and applies a [workaround suggested by the HHVM team](http://hhvm.com/blog/3095/getting-wordpress-running-on-hhvm), which consists of declaring multiple variations of the `OBJECT` constant.
