### PR TITLE
Overall improvement of PHPDoc comments.

### DIFF
--- a/WP_Mock/API/function-mocks.php
+++ b/WP_Mock/API/function-mocks.php
@@ -25,20 +25,22 @@ if ( ! function_exists( 'do_action' ) ) {
 	 *
 	 * @param string $tag     The name of the action to be executed.
 	 * @param mixed  $arg,... Optional additional arguments which are passed on to the functions hooked to the action.
-	 *
-	 * @return null Will return null if $tag does not exist in $wp_filter array
 	 */
 	function do_action( $tag, $arg = '' ) {
 		$args = func_get_args();
 		$args = array_slice( $args, 1 );
-
-		return \WP_Mock::onAction( $tag )->react( $args );
+		\WP_Mock::onAction( $tag )->react( $args );
 	}
 }
 
 if ( ! function_exists( 'add_filter' ) ) {
 	/**
 	 * Dummy method to prevent filter hooks in constructor from failing.
+	 *
+	 * @param string   $tag The name of the filter to which the $function_to_add is hooked.
+	 * @param callback $function_to_add The name of the function you wish to be called.
+	 * @param int      $priority        optional. Used to specify the order in which the functions associated with a particular filter are executed (default: 10). Lower numbers correspond with earlier execution, and functions with the same priority are executed in the order in which they were added to the filter.
+	 * @param int      $accepted_args   optional. The number of arguments the function accept (default 1).
 	 */
 	function add_filter( $tag, $function_to_add, $priority = 10, $accepted_args = 1 ) {
 		\WP_Mock::onFilterAdded( $tag )->react( $function_to_add, (int) $priority, (int) $accepted_args );
@@ -51,7 +53,6 @@ if ( ! function_exists( 'apply_filters' ) ) {
 	 *
 	 * @param string $tag     The name of the filter hook.
 	 * @param mixed  $value   The value on which the filters hooked to <tt>$tag</tt> are applied on.
-	 * @param mixed  $var,... Additional variables passed to the functions hooked to <tt>$tag</tt>.
 	 *
 	 * @return mixed The filtered value after all hooked functions are applied to it.
 	 */

--- a/WP_Mock/Action.php
+++ b/WP_Mock/Action.php
@@ -11,6 +11,10 @@ namespace WP_Mock;
 
 
 class Action extends Hook {
+
+	/**
+	 * @param array $args
+	 */
 	public function react( $args ) {
 		\WP_Mock::invokeAction( $this->name );
 
@@ -43,6 +47,9 @@ class Action extends Hook {
 		}
 	}
 
+	/**
+	 * @return Action_Responder
+	 */
 	protected function new_responder() {
 		return new Action_Responder();
 	}
@@ -54,6 +61,9 @@ class Action_Responder {
 	 */
 	protected $callable;
 
+	/**
+	 * @param mixed $callable
+	 */
 	public function perform( $callable ) {
 		$this->callable = $callable;
 	}

--- a/WP_Mock/EventManager.php
+++ b/WP_Mock/EventManager.php
@@ -4,20 +4,23 @@ namespace WP_Mock;
 
 class EventManager {
 	/**
-	 * @var array
+	 * @var Filter[]
 	 */
 	protected $filters;
 
 	/**
-	 * @var array
+	 * @var Action[]
 	 */
 	protected $actions;
 
 	/**
-	 * @var array
+	 * @var string[]
 	 */
 	protected $expected;
 
+	/**
+	 * @var HookedCallback[]
+	 */
 	protected $callbacks;
 
 	public function __construct() {
@@ -61,6 +64,12 @@ class EventManager {
 		return $this->filters[ $name ];
 	}
 
+	/**
+	 * @param string $name
+	 * @param string $type Optional. Defaults to 'filter'.
+	 *
+	 * @return HookedCallback
+	 */
 	public function callback( $name, $type = 'filter' ) {
 		$type_name = "$type::$name";
 		if ( ! isset( $this->callbacks[$type_name] ) ) {
@@ -75,7 +84,7 @@ class EventManager {
 	 * Remember that a particular hook has been invoked during operation.
 	 *
 	 * @param string $hook
-	 * @param string $type
+	 * @param string $type Optional. Defaults to 'action'.
 	 */
 	public function called( $hook, $type = 'action' ) {
 		$position = array_search( $type . '::' . $hook, $this->expected );
@@ -91,6 +100,11 @@ class EventManager {
 		return array_keys( $this->actions );
 	}
 
+	/**
+	 * Return a list of all the callbacks we're expecting a test to invoke.
+	 *
+	 * @return array
+	 */
 	public function expectedHooks() {
 		return array_keys( $this->callbacks );
 	}
@@ -110,6 +124,11 @@ class EventManager {
 		return true;
 	}
 
+	/**
+	 * Check whether or not all actions have been added at least once.
+	 *
+	 * @return bool
+	 */
 	public function allHooksAdded() {
 		foreach( $this->expected as $hook ) {
 			if ( 0 === strpos( $hook, 'callback::' ) ) {

--- a/WP_Mock/Filter.php
+++ b/WP_Mock/Filter.php
@@ -40,6 +40,9 @@ class Filter extends Hook {
 		return $processors->send();
 	}
 
+	/**
+	 * @return Filter_Responder
+	 */
 	protected function new_responder() {
 		return new Filter_Responder();
 	}
@@ -52,12 +55,17 @@ class Filter_Responder {
 	 */
 	protected $value;
 
+	/**
+	 * @param mixed $value
+	 */
 	public function reply( $value ) {
 		$this->value = $value;
 	}
 
+	/**
+	 * @return mixed
+	 */
 	public function send() {
 		return $this->value;
 	}
 }
-

--- a/WP_Mock/Functions.php
+++ b/WP_Mock/Functions.php
@@ -6,12 +6,24 @@ use Mockery;
 
 class Functions {
 
+	/**
+	 * @var array
+	 */
 	private $mocked_functions = array();
 
+	/**
+	 * @var array
+	 */
 	private $internal_functions = array();
 
+	/**
+	 * @var array
+	 */
 	private static $wp_mocked_functions = array();
 
+	/**
+	 * @var array
+	 */
 	private $patchwork_functions = array();
 
 	/**
@@ -94,11 +106,11 @@ class Functions {
 	/**
 	 * Set up the mock object with an expectation for this test.
 	 *
-	 * @param \Mockery\Mock $mock
+	 * @param Mockery\Mock $mock
 	 * @param string        $function
 	 * @param array         $arguments
 	 */
-	protected function set_up_mock( $mock, $function, $arguments ) {
+	protected function set_up_mock( Mockery\Mock $mock, $function, $arguments ) {
 		$expectation = $mock->shouldReceive( $function );
 
 		if ( isset( $arguments['times'] ) ) {
@@ -159,7 +171,7 @@ class Functions {
 	 *
 	 * This function is namespace-aware.
 	 *
-	 * @param $function_name
+	 * @param string $function_name
 	 */
 	private function generate_function( $function_name ) {
 		$function_name = $this->sanitize_function_name( $function_name );
@@ -269,4 +281,3 @@ EOF;
 	}
 
 }
-

--- a/WP_Mock/Handler.php
+++ b/WP_Mock/Handler.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Created by JetBrains PhpStorm.
- * User: Eric
- * Date: 3/26/13
- * Time: 8:56 AM
- * To change this template use File | Settings | File Templates.
- */
 
 namespace WP_Mock;
 
@@ -32,7 +25,7 @@ class Handler {
 	 * Handle a mocked function call.
 	 *
 	 * @param string $function_name
-	 * @param array  $args
+	 * @param array  $args          Optional. Defaults to array().
 	 *
 	 * @return mixed
 	 */

--- a/WP_Mock/Hook.php
+++ b/WP_Mock/Hook.php
@@ -16,10 +16,18 @@ abstract class Hook {
 	/** @var array Collection of processors */
 	protected $processors = array();
 
+	/**
+	 * @param string $name
+	 */
 	public function __construct( $name ) {
 		$this->name = $name;
 	}
 
+	/**
+	 * @param mixed $value
+	 *
+	 * @return string
+	 */
 	protected function safe_offset( $value ) {
 		if(is_null($value)){
 			return 'null';

--- a/WP_Mock/HookedCallback.php
+++ b/WP_Mock/HookedCallback.php
@@ -4,6 +4,13 @@ namespace WP_Mock;
 
 class HookedCallback extends Hook {
 
+	/**
+	 * @param string $callback
+	 * @param int    $priority
+	 * @param int    $argument_count
+	 *
+	 * @return null
+	 */
 	public function react( $callback, $priority, $argument_count ) {
 		\WP_Mock::addHook( $this->name );
 
@@ -13,10 +20,18 @@ class HookedCallback extends Hook {
 		) ? $this->processors[$this->safe_offset( $callback )][$priority][$argument_count]->react() : null;
 	}
 
+	/**
+	 * @return HookedCallbackResponder
+	 */
 	protected function new_responder() {
 		return new HookedCallbackResponder();
 	}
 
+	/**
+	 * @param mixed $value
+	 *
+	 * @return string
+	 */
 	protected function safe_offset( $value ) {
 		if ( $value instanceof \Closure ) {
 			$value = '__CLOSURE__';
@@ -33,6 +48,9 @@ class HookedCallbackResponder {
 	 */
 	protected $callable;
 
+	/**
+	 * @param callable $callable
+	 */
 	public function perform( $callable ) {
 		$this->callable = $callable;
 	}

--- a/WP_Mock/Loader.php
+++ b/WP_Mock/Loader.php
@@ -21,16 +21,33 @@ namespace WP_Mock;
 
 
 class Loader {
+
+	/**
+	 * @var string
+	 */
 	private $_fileExtension = '.php';
+
+	/**
+	 * @var string
+	 */
 	private $_namespace;
+
+	/**
+	 * @var string
+	 */
 	private $_includePath;
+
+	/**
+	 * @var string
+	 */
 	private $_namespaceSeparator = '\\';
 
 	/**
 	 * Creates a new <tt>Loader</tt> that loads classes of the
 	 * specified namespace.
 	 *
-	 * @param string $ns The namespace to use.
+	 * @param string $ns          The namespace to use.
+	 * @param string $includePath Optional. Defaults to null.
 	 */
 	public function __construct( $ns = 'WP_Mock', $includePath = null ) {
 		$this->_namespace   = $ns;
@@ -49,7 +66,7 @@ class Loader {
 	/**
 	 * Gets the namespace seperator used by classes in the namespace of this class loader.
 	 *
-	 * @return void
+	 * @return string
 	 */
 	public function getNamespaceSeparator() {
 		return $this->_namespaceSeparator;
@@ -111,8 +128,6 @@ class Loader {
 	 * Loads the given class or interface.
 	 *
 	 * @param string $className The name of the class to load.
-	 *
-	 * @return void
 	 */
 	public function loadClass( $className ) {
 		return;

--- a/WP_Mock/Matcher/FuzzyObject.php
+++ b/WP_Mock/Matcher/FuzzyObject.php
@@ -8,7 +8,7 @@ use Mockery\Matcher\MatcherAbstract;
 class FuzzyObject extends MatcherAbstract {
 
 	/**
-	 * @param object|array $expected
+	 * @param object|array $expected Optional. Defaults to null.
 	 *
 	 * @throws \Mockery\Exception If a non-object non-array expectation is provided
 	 */

--- a/WP_Mock/ReturnSequence.php
+++ b/WP_Mock/ReturnSequence.php
@@ -4,6 +4,9 @@ namespace WP_Mock;
 
 class ReturnSequence {
 
+	/**
+	 * @var array
+	 */
 	private $return_values = array();
 
 	/**

--- a/WP_Mock/Tools/Constraints/ExpectationsMet.php
+++ b/WP_Mock/Tools/Constraints/ExpectationsMet.php
@@ -10,6 +10,11 @@ class ExpectationsMet extends PHPUnit_Framework_Constraint {
 
 	private $_mockery_message;
 
+	/**
+	 * @param mixed $other Unused.
+	 *
+	 * @return bool
+	 */
 	public function matches( $other ) {
 		try {
 			Mockery::getContainer()->mockery_verify();
@@ -29,10 +34,20 @@ class ExpectationsMet extends PHPUnit_Framework_Constraint {
 		return 'WP Mock expectations are met';
 	}
 
+	/**
+	 * @param mixed $other Unused.
+	 *
+	 * @return string
+	 */
 	protected function additionalFailureDescription( $other ) {
 		return str_replace( array( "\r", "\n" ), '', (string) $this->_mockery_message );
 	}
 
+	/**
+	 * @param mixed $other Unused.
+	 *
+	 * @return string
+	 */
 	protected function failureDescription( $other ) {
 		return $this->toString();
 	}

--- a/WP_Mock/Tools/Constraints/IsEqualHtml.php
+++ b/WP_Mock/Tools/Constraints/IsEqualHtml.php
@@ -6,15 +6,29 @@ use PHPUnit_Framework_Constraint_IsEqual;
 
 class IsEqualHtml extends PHPUnit_Framework_Constraint_IsEqual {
 
+	/**
+	 * @param string $thing
+	 *
+	 * @return string
+	 */
 	private function clean( $thing ) {
 		$thing = preg_replace( '/\n\s+/', '', $thing );
 		$thing = preg_replace( '/\s\s+/', ' ', $thing );
+
 		return str_replace( array( "\r", "\n", "\t" ), '', $thing );
 	}
 
+	/**
+	 * @param mixed  $other
+	 * @param string $description  Optional. Defaults to ''.
+	 * @param bool   $returnResult Optional. Defaults to FALSE.
+	 *
+	 * @return mixed
+	 */
 	public function evaluate( $other, $description = '', $returnResult = FALSE ) {
 		$other       = $this->clean( $other );
 		$this->value = $this->clean( $this->value );
+
 		return parent::evaluate( $other, $description, $returnResult );
 	}
 

--- a/WP_Mock/Tools/TestCase.php
+++ b/WP_Mock/Tools/TestCase.php
@@ -92,10 +92,18 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		$this->assertEmpty( $hooks_not_added, $expected_hooks );
 	}
 
+	/**
+	 * @param string $content
+	 *
+	 * @return string
+	 */
 	public function stripTabsAndNewlines( $content ) {
 		return str_replace( array( "\t", "\r", "\n" ), '', $content );
 	}
 
+	/**
+	 * @param string $expectedString
+	 */
 	public function expectOutputString( $expectedString ) {
 		if ( is_callable( $this->__contentFilterCallback ) ) {
 			$expectedString = call_user_func( $this->__contentFilterCallback, $expectedString );
@@ -103,14 +111,25 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		parent::expectOutputString( $expectedString );
 	}
 
+	/**
+	 * @param string $message Optional. Defaults to ''.
+	 */
 	public function assertCurrentConditionsMet( $message = '' ) {
 		$this->assertThat( null, new ExpectationsMet, $message );
 	}
 
+	/**
+	 * @param string $message Optional. Defaults to ''.
+	 */
 	public function assertConditionsMet( $message = '' ) {
 		$this->assertCurrentConditionsMet( $message );
 	}
 
+	/**
+	 * @param string $expected
+	 * @param string $actual
+	 * @param string $message  Optional. Defaults to ''.
+	 */
 	public function assertEqualsHTML( $expected, $actual, $message = '' ) {
 		$constraint = new IsEqualHtml( $expected );
 		$this->assertThat( $actual, $constraint, $message );
@@ -185,4 +204,3 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	}
 
 }
-


### PR DESCRIPTION
What this pull request does:
* add PHPDoc comments for functions that:
  * have parameters;
  * return something;
* use type hinting (where appropriate);
* remove an irrelevant auto-generated PHPDoc comment;
* use Unix line separators.