### PR TITLE
Introduce assertOutputEqualsHTML

### DIFF
--- a/WP_Mock/Tools/TestCase.php
+++ b/WP_Mock/Tools/TestCase.php
@@ -117,6 +117,16 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
+	 * @param string $expected Expected HTML string.
+	 * @param string $message  Optional. Additional information about the test. Defaults to ''.
+	 */
+	public function assertOutputEqualsHTML( $expected, $message = '' ) {
+		$actual = $this->getActualOutput();
+		$constraint = new IsEqualHtml( $expected );
+		$this->assertThat( $actual, $constraint, $message );
+	}
+
+	/**
 	 * Mock a static method of a class
 	 *
 	 * @param string      $class  The classname or class::method name


### PR DESCRIPTION
What this pull request does:
* introduce a new assertion method `assertOutputEqualsHTML()`.

<hr>

Yes, there is the expectation method `expectOutputString()`, but this does not include an assertion.  
And yes, there is also the assertion method `assertEqualsHTML`, but this has to be fed with both the expected and the actual HTML string.

In case one would like to check whether or not the current **output** was equal to a specific HTML string, one either would have to output buffer or use the `getActualOutput()` method. But since it seems more likely that one would like to compare the current output with another HTML string (instead of comparing two variable), the short-hand method in this pull request's commit seems beneficial.