### PR TITLE
Introduce wpEchoFunction()

### DIFF
--- a/WP_Mock.php
+++ b/WP_Mock.php
@@ -353,6 +353,26 @@ class WP_Mock {
 	}
 
 	/**
+	 * A wrapper for wpFunction that will simply set/override the return to be
+	 * a function that echoes the value that its passed. For example, esc_attr_e
+	 * may need to be mocked, and it must echo some value. wpEchoFunction will
+	 * set esc_attr_e to echo the value its passed.
+	 *
+	 *    \WP_Mock::wpEchoFunction( 'esc_attr_e' );
+	 *    esc_attr_e( 'some_value' ); // echoes (maybe translated) "some_value"
+	 *
+	 * @param string $function_name Function name.
+	 * @param array  $arguments     Optional. Arguments. Defaults to array().
+	 */
+	public static function wpEchoFunction( $function_name, $arguments = array() ) {
+		$arguments           = (array) $arguments;
+		$arguments['return'] = function ( $param ) {
+			echo $param;
+		};
+		self::$function_manager->register( $function_name, $arguments );
+	}
+
+	/**
 	 * Generate a fuzzy object match expectation
 	 *
 	 * This will let you fuzzy match objects based on their properties without


### PR DESCRIPTION
What this pull request does:
* introduce the `wpEchoFunction` method.

Basically, it works like the `wpPassthruFunction` method, however, it doesn't return but echo its first argument.

This way, instead of writing something like this

```php
WP_Mock::wpFunction(
	'esc_attr_e',
	array(
		'return' => function () {
			$args = func_get_args();
			echo $args[ 0 ];
		},
	)
);
```
you are just fine with this

```php
WP_Mock::wpEchoFunction( 'esc_attr_e' );
```
