### PR TITLE
Introduce echoFunction

### DIFF
--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -344,6 +344,26 @@ class WP_Mock {
 
 	/**
 	 * A wrapper for userFunction that will simply set/override the return to be
+	 * a function that echoes the value that its passed. For example, esc_attr_e
+	 * may need to be mocked, and it must echo some value. echoFunction will set
+	 * esc_attr_e to echo the value its passed.
+	 *
+	 *    \WP_Mock::echoFunction( 'esc_attr_e' );
+	 *    esc_attr_e( 'some_value' ); // echoes (translated) "some_value"
+	 *
+	 * @param string $function_name Function name.
+	 * @param array  $arguments     Optional. Arguments. Defaults to array().
+	 */
+	public static function echoFunction( $function_name, $arguments = array() ) {
+		$arguments           = (array) $arguments;
+		$arguments['return'] = function ( $param ) {
+			return $param;
+		};
+		self::$function_manager->register( $function_name, $arguments );
+	}
+
+	/**
+	 * A wrapper for userFunction that will simply set/override the return to be
 	 * a function that returns the value that its passed. For example, esc_attr
 	 * may need to be mocked, and it must return some value. passthruFunction
 	 * will set esc_attr to return the value its passed.


### PR DESCRIPTION
What this pull request does:
- introduce the `echoFunction` method.

Basically, it works like the `passthruFunction` method, however, it doesn't return but echo its first argument.

This way, instead of writing something like this

``` php
WP_Mock::userFunction(
    'esc_attr_e',
    array(
        'return' => function ( $param ) {
            echo $param;
        },
    )
);
```

you are just fine with this

``` php
WP_Mock::echoFunction( 'esc_attr_e' );
```
