### PR TITLE
Remove redundant cleanup

### DIFF
--- a/php/WP_Mock/Functions.php
+++ b/php/WP_Mock/Functions.php
@@ -18,7 +18,6 @@ class Functions {
 	 * Constructor for the Functions object
 	 */
 	public function __construct() {
-		Handler::cleanup();
 		$this->flush();
 	}
 


### PR DESCRIPTION
What this pull request does:
* remove a redundant call to `Handler::cleanup()`.

`Handler::cleanup()` will be called in `flush()` anyway. In the latter method, first a private property is reset, but there are no side-effects whatsoever.