### PR TITLE
Feature/add assertions for expect not added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.lock
 vendor/
 docs/
+.editorconfig

--- a/bootstrap.php.dist
+++ b/bootstrap.php.dist
@@ -1,0 +1,6 @@
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+WP_Mock::setUsePatchwork( false );
+WP_Mock::bootstrap();

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -232,6 +232,17 @@ class WP_Mock {
 	}
 
 	/**
+	 * Add an expection that an action should not be added. A wrapper
+	 * around the expectHookNotAdded function.
+	 *
+	 * @param string   $action   The action hook name
+	 * @param callable $callback The action callback
+	 */
+	public static function expectActionNotAdded( $action, $callback ) {
+		self::expectHookNotAdded( 'action', $action, $callback );
+	}
+
+	/**
 	 * Add an expectation that a filter should be added
 	 *
 	 * Really just a wrapper function for expectHookAdded()
@@ -243,6 +254,17 @@ class WP_Mock {
 	 */
 	public static function expectFilterAdded( $filter, $callback, $priority = 10, $args = 1 ) {
 		self::expectHookAdded( 'filter', $filter, $callback, $priority, $args );
+	}
+
+	/**
+	 * Adds an expectation that a filter will not be added. A wrapper
+	 * around the expectHookNotAdded function.
+	 *
+	 * @param string   $action   The filter hook name
+	 * @param callable $callback The filter callback
+	 */
+	public static function expectFilterNotAdded( $filter, $callback ) {
+		self::expectHookNotAdded( 'filter', $filter, $callback );
 	}
 
 	/**
@@ -261,6 +283,24 @@ class WP_Mock {
 		/** @var WP_Mock\HookedCallbackResponder $responder */
 		$responder = self::onHookAdded( $action, $type )
 			->with( $callback, $priority, $args );
+		$responder->perform( array( $intercept, 'intercepted' ) );
+	}
+
+	/**
+	 * Adds an expectation that a hook should not be added. Based on the
+	 * shouldNotReceive API of Mocker.
+	 *
+	 * @param    string   $type     The hook type, 'action' or 'filter'
+	 * @param    string   $action   The name of the hook
+	 * @callback callable $callback The hooks callback handler.
+	 */
+	public static function expectHookNotAdded( $type, $action, $callback ) {
+		$intercept = \Mockery::mock( 'intercept' );
+		$intercept->shouldNotReceive( 'intercepted' );
+
+		/** @var WP_Mock\HookedCallbackResponder $responder */
+		$responder = self::onHookAdded( $action, $type )
+			->with( $callback, 10, 1 );
 		$responder->perform( array( $intercept, 'intercepted' ) );
 	}
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,9 @@
+<phpunit
+		bootstrap="./bootstrap.php.dist"
+		colors="true">
+	<testsuites>
+		<testsuite>
+			<directory suffix="Test.php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/ExpectNotAddedTest.php
+++ b/tests/ExpectNotAddedTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use WP_Mock\Tools\TestCase;
+
+class ExpectNotAddedTest extends TestCase {
+
+	public $callback;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->callback = array( $this, 'handler' );
+	}
+
+	/* expected failure */
+	public function test_expect_action_not_added_fails_if_action_was_added() {
+		WP_Mock::expectActionNotAdded(
+			'foo_action', $this->callback
+		);
+
+		add_action( 'foo_action', array( $this, 'handler' ) );
+	}
+
+	public function test_expect_action_not_added_does_not_fail_if_action_was_not_added() {
+		WP_Mock::expectActionNotAdded(
+			'foo_action', $this->callback
+		);
+	}
+
+	/* expected failure */
+	public function test_expect_filter_not_added_fails_if_filter_was_added() {
+		WP_Mock::expectFilterNotAdded(
+			'foo_filter', $this->callback
+		);
+
+		add_filter( 'foo_filter', array( $this, 'handler' ) );
+	}
+
+	public function test_expect_filter_not_added_does_not_fail_if_filter_was_not_added() {
+		WP_Mock::expectFilterNotAdded(
+			'foo_filter', $this->callback
+		);
+	}
+
+	/* helpers */
+	public function handler() {
+
+	}
+
+}


### PR DESCRIPTION
This PR adds assertion functions for checking the absence of adding Actions or Filters. My use case is similar to the one discussed by @stevegrunwell in #30. ie:- Checking if `add_action` or `add_filter` were called upon execution of some application code.

The API for these new assertions is,

``` php
WP_Mock::expectActionNotAdded( $action, $callback );

WP_Mock::expectFilterNotAdded( $filter, $callback );
```

I have also added PHP Unit configuration and basic tests to show these helpers in action.

Thanks!

/cc @johnpbloch 
