### PR TITLE
Allow `userFunction` to return the `Mockery\Mock` object

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,20 @@ $this->assertFalse( is_single() ); // All subsequent calls will use the last def
 
 Use this to specify that the function should return one of its arguments. `return_arg` should be the position of the argument in the arguments array, so `0` for the first argument, `1` for the second, etc. You can also set this to `true`, which is equivalent to `0`. This will override both `return` and `return_in_order`.
 
+### Using Mockery expectations
+
+The return value of `\WP_Mock::userFunction` will be a complete `Mockery\Mock` object with any expectations added to match the arguments passed to the function. This enables using [Mockery methods](http://docs.mockery.io/en/latest/reference/expectations.html) to add expectations in addition to, or instead of using the arguments array passed to `userFunction`.
+
+For example, the following are synonymous:
+
+```php
+\WP_Mock::userFunction( 'get_permalink', array( 'args' => 42, 'return' => 'http://example.com/foo' ) );
+```
+
+```php
+\WP_Mock::userFunction( 'get_permalink' )->with( 42 )->andReturn( 'http://example.com/foo' );
+```
+
 ### Passthru functions
 
 It's not uncommon for tests to need to declare "passthrough/passthru" functions: empty functions that just return whatever they're passed (remember: you're testing your code, not the framework). In these situations you can use `\WP_Mock::passthruFunction( 'function_name' )`, which is equivalent to the following:

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -325,11 +325,18 @@ class WP_Mock {
 	 *   something like this:
 	 *     array( $post->ID, 'some_meta_key', true )
 	 *
+	 *  Returns the Mockery\Mock object with the function expectations added. It
+	 *  is possible to use Mockery methods to add expectations to the object
+	 *  returned, which will then be combined with any expectations that may have
+	 *  been passed as arguments.
+	 *
 	 * @param string $function_name
 	 * @param array  $arguments
+	 *
+	 * @return Mockery\Mock
 	 */
 	public static function userFunction( $function_name, $arguments = array() ) {
-		self::$function_manager->register( $function_name, $arguments );
+		return self::$function_manager->register( $function_name, $arguments );
 	}
 
 	/**

--- a/php/WP_Mock/Functions.php
+++ b/php/WP_Mock/Functions.php
@@ -49,8 +49,11 @@ class Functions {
 	 * @param array  $arguments
 	 *
 	 * @throws \Exception If the function name is invalid
+	 *
+	 * @return Mockery\Mock
 	 */
 	public function register( $function, $arguments ) {
+		$expectation = null;
 		try {
 			$this->generate_function( $function );
 			if ( empty( $this->mocked_functions[$function] ) ) {
@@ -59,11 +62,12 @@ class Functions {
 			$mock = $this->mocked_functions[$function];
 
 			$method = preg_replace( '/\\\\+/', '_', $function );
-			$this->set_up_mock( $mock, $method, $arguments );
+			$expectation = $this->set_up_mock( $mock, $method, $arguments );
 			Handler::register_handler( $function, array( $mock, $method ) );
 		} catch ( \Exception $e ) {
 			throw $e;
 		}
+		return $expectation;
 	}
 
 	/**
@@ -97,6 +101,8 @@ class Functions {
 	 * @param \Mockery\Mock $mock
 	 * @param string        $function
 	 * @param array         $arguments
+	 *
+	 * @return Mockery\Mock
 	 */
 	protected function set_up_mock( $mock, $function, $arguments ) {
 		$expectation = $mock->shouldReceive( $function );
@@ -152,6 +158,7 @@ class Functions {
 				$expectation->andReturn( $return );
 			}
 		}
+		return $expectation;
 	}
 
 	/**


### PR DESCRIPTION
This enables using [Mockery methods](http://docs.mockery.io/en/latest/reference/expectations.html) to add expectations in addition to, or instead of using the arguments array passed to `userFunction`.

For example, the following are synonymous:

``` php
\WP_Mock::userFunction( 'get_permalink', array( 'args' => 42, 'return' => 'http://example.com/foo' ) );
```

``` php
\WP_Mock::userFunction( 'get_permalink' )->with( 42 )->andReturn( 'http://example.com/foo' );
```

Fixes #53 
