### PR TITLE
Allow `wpFunction` alias to return a `Mockery\Mock`

### DIFF
--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -344,9 +344,11 @@ class WP_Mock {
 	 *
 	 * @param string $function_name
 	 * @param array  $arguments
+	 *
+	 * @return Mockery\Mock
 	 */
 	public static function wpFunction( $function_name, $arguments = array() ) {
-		self::userFunction( $function_name, $arguments );
+		return self::userFunction( $function_name, $arguments );
 	}
 
 	/**


### PR DESCRIPTION
Now that `userFunction` returns a Mockery object, its alias should probably also return that value.

Oops. I should have seen that in #54 
