### PR TITLE
Add common functions to the list of WP_Mock mocked functions

### DIFF
--- a/php/WP_Mock/Functions.php
+++ b/php/WP_Mock/Functions.php
@@ -38,6 +38,22 @@ class Functions {
 				'do_action',
 				'add_filter',
 				'apply_filters',
+				'esc_attr',
+				'esc_html',
+				'esc_js',
+				'esc_textarea',
+				'esc_url',
+				'esc_url_raw',
+				'__',
+				'_e',
+				'_x',
+				'esc_attr__',
+				'esc_attr_e',
+				'esc_attr_x',
+				'esc_html__',
+				'esc_html_e',
+				'esc_html_x',
+				'_n',
 			);
 		}
 	}


### PR DESCRIPTION
This prevents a bug in which patchwork tries to redefine any of the functions that were merged in #76, but they were included before patchwork runs.