### PR TITLE
Patchwork 2.0.3 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"php"                 : ">=5.3.2",
 		"phpunit/phpunit"     : ">=4.3",
 		"mockery/mockery"     : "^0.9.5",
-		"antecedent/patchwork": "~1.3.4"
+		"antecedent/patchwork": "~2.0.3"
 	},
 	"require-dev": {
 		"behat/behat"         : "^3.0"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "5.3.3"
+			"php": "5.4.0"
 		}
 	},
 	"scripts": {

--- a/php/WP_Mock/Functions.php
+++ b/php/WP_Mock/Functions.php
@@ -30,7 +30,7 @@ class Functions {
 		Handler::cleanup();
 		$this->patchwork_functions = array();
 		if ( function_exists( 'Patchwork\undoAll' ) ) {
-			\Patchwork\undoAll();
+			\Patchwork\restoreAll();
 		}
 		if ( empty( self::$wp_mocked_functions ) ) {
 			self::$wp_mocked_functions = array(
@@ -239,7 +239,7 @@ EOF;
 			return true;
 		}
 		$this->patchwork_functions[] = $function_name;
-		\Patchwork\replace( $function_name, function () use ( $function_name ) {
+		\Patchwork\redefine( $function_name, function () use ( $function_name ) {
 			return Handler::handle_function( $function_name, func_get_args() );
 		} );
 		return true;

--- a/php/WP_Mock/Tools/TestCase.php
+++ b/php/WP_Mock/Tools/TestCase.php
@@ -194,7 +194,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 			$mock->shouldAllowMockingProtectedMethods();
 			$this->mockedStaticMethods[ $signature ] = $mock;
 
-			\Patchwork\Interceptor\patch( "$class::$method", function () use ( $mock, $safe_method ) {
+			\Patchwork\redefine( "$class::$method", function () use ( $mock, $safe_method ) {
 				return call_user_func_array( array( $mock, $safe_method ), func_get_args() );
 			}, ! ( $rMethod ) );
 		}


### PR DESCRIPTION
Not entierly sure what should happen at
`php/WP_Mock/Tools/TestCase.php +197` as `patch()` at version [1.3.4](https://github.com/antecedent/patchwork/blob/1a6197903bdc1d0d8b4c5218a9a0b60ed8ddc385/src/Interceptor.php#L20)  has only 2 arguments in the first place.

Also I see that the project has PHP 5.3 as a dependency, could we get a package with  >5.4?