### PR TITLE
Update installation instructions to pull correct branch via composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ WP_Mock is an API mocking framework, built and maintained by [10up](http://10up.
 First, add WP Mock as a dev-dependency with [Composer](http://getcomposer.org):
 
 ```bash
-composer require --dev 10up/wp_mock:dev-master
+composer require --dev 10up/wp_mock:dev-dev
 ```
 
 Then, make sure your bootstrap file is loading the composer autoloader:


### PR DESCRIPTION
Ran into issues setting up a simple test case following the instructions [here](https://github.com/10up/wp_mock#using-wp_mock). Resolved by updating the target branch with `composer require` (dev instead of master). 