### PR TITLE
Bump PHP Requirements to 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,18 @@ language: php
 
 matrix:
   include:
-    - php: '5.3'
-      env: WP_MOCK_INSTALL_LOWEST=0
     - php: '5.6'
       env: WP_MOCK_INSTALL_LOWEST=0
     - php: '7.0'
       env: WP_MOCK_INSTALL_LOWEST=0
-    - php: '5.3'
-      env: WP_MOCK_INSTALL_LOWEST=1
+    - php: '7.1'
+      env: WP_MOCK_INSTALL_LOWEST=0
     - php: '5.6'
       env: WP_MOCK_INSTALL_LOWEST=1
     - php: '7.0'
       env: WP_MOCK_INSTALL_LOWEST=1
+    - php: '7.1'
+      env: WP_MOCK_INSTALL_LOWEST=0
 
 before_script:
   - if [ 1 -eq $WP_MOCK_INSTALL_LOWEST ]; then composer update --prefer-lowest; else composer update; fi

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "A mocking library to take the pain out of unit testing for WordPress",
 	"license"    : "GPL-2.0+",
 	"require"    : {
-		"php"                 : ">=5.3.2",
+		"php"                 : ">=5.6",
 		"phpunit/phpunit"     : ">=4.3",
 		"mockery/mockery"     : "^0.9.5",
 		"antecedent/patchwork": "~2.0.3"

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
 	},
 	"config": {
 		"platform": {
-			"php": "5.4.0"
+			"php": "5.6.0"
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
While WordPress itself supports older versions of PHP, not every development tool does. Some of the dependencies of WP_Mock require _at least_ 5.4 for short array syntax. Others take hard stances on only supporting active versions of PHP (meaning anything older than 5.6 is out as well).

While you can definitely test your PHP 5.2-5.5 code with WP_Mock, you should do so on a modern engine (like PHP 5.6) otherwise many of the required tools will fail. This has broken Travis multiple times and blocked our merge process that requires passing tests!

We're joining the PHP community by taking a hard stance to require _at least_ PHP 5.6 for _running_ WP_Mock. Please make any updates accordingly.