### PR TITLE
Added PHPDoc

### DIFF
--- a/php/WP_Mock/Hook.php
+++ b/php/WP_Mock/Hook.php
@@ -40,6 +40,7 @@ abstract class Hook {
 		return '';
 	}
 
+	/** @return Action_Responder|Filter_Responder */
 	public function with() {
 		$args      = func_get_args();
 		$responder = $this->new_responder();


### PR DESCRIPTION
`\WP_Mock\Hook::with` returns either an instance of `Action_Responder` or `Filter_Responder`.

See #95