### PR TITLE
Add an expectFilter method

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,30 @@ public function test_filter_content() {
 }
 ```
 
+Alternatively, there is a method `\WP_Mock::expectFilter()` that will add a bare assertion that the filter will be applied without changing the value:
+
+```php
+class SUT {
+	public function filter_content() {
+		$value = apply_filters( 'custom_content_filter', 'Default' );
+		if ( $value === 'Default' ) {
+			do_action( 'default_value' );
+		}
+
+		return $value;
+	}
+}
+
+class SUTTest {
+	public function test_filter_content() {
+		\WP_Mock::expectFilter( 'custom_content_filter', 'Default' );
+		\WP_Mock::expectAction( 'default_value' );
+
+		$this->assertEquals( 'Default', (new SUT)->filter_content() );
+	}
+}
+```
+
 ### Mocking WordPress objects
 
 Mocking calls to `wpdb`, `WP_Query`, etc. can be done using the [mockery](https://github.com/padraic/mockery) framework.  While this isn't part of WP Mock itself, complex code will often need these objects and this framework will let you incorporate those into your tests.  Since WP Mock requires Mockery, it should already be included as part of your install.

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
 		"antecedent/patchwork": "~2.0.3"
 	},
 	"require-dev": {
-		"behat/behat"         : "^3.0"
+		"behat/behat"         : "^3.0",
+		"sebastian/comparator": ">=1.2.3"
 	},
 	"conflict": {
 		"phpunit/phpunit": ">=6.0"

--- a/features/bootstrap/HooksContext.php
+++ b/features/bootstrap/HooksContext.php
@@ -66,6 +66,25 @@ class HooksContext implements Context {
 	}
 
 	/**
+	 * @Given I expect the :filter filter with :value
+	 */
+	public function iExpectTheFilterWith( $filter, $value ) {
+		$this->iExpectTheFilterWithValues( $filter, new TableNode( array( array( $value ) ) ) );
+	}
+
+	/**
+	 * @When I expect the :filter filter with:
+	 */
+	public function iExpectTheFilterWithValues( $filter, TableNode $table ) {
+		$args = array( $filter );
+		$rows = $table->getRows();
+		if ( isset( $rows[0] ) && is_array( $rows[0] ) ) {
+			$args = array_merge( $args, $rows[0] );
+		}
+		call_user_func_array( array( 'WP_Mock', 'expectFilter' ), $args );
+	}
+
+	/**
 	 * @When I add the following actions:
 	 */
 	public function iAddTheFollowingActions( TableNode $table ) {
@@ -161,7 +180,16 @@ class HooksContext implements Context {
 	 * @When I apply the filter :filter with :with
 	 */
 	public function iApplyFilterWith( $filter, $with ) {
-		$this->filterResults[ $filter ] = apply_filters( $filter, $with );
+		$this->iApplyFilterWithData( $filter, new TableNode( array( array( $with ) ) ) );
+	}
+
+	/**
+	 * @When I apply the filter :filter with:
+	 */
+	public function iApplyFilterWithData( $filter, TableNode $table ) {
+		$row = $table->getRow( 0 );
+		array_unshift( $row, $filter );
+		$this->filterResults[ $filter ] = call_user_func_array( 'apply_filters', $row );
 	}
 
 	/**

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -118,6 +118,42 @@ Feature: Hook mocking
       | data | plus |
     Then tearDown should fail
 
+  Scenario: expectFilter sets up expectation
+    Given I expect the "foobar" filter with "bazbat"
+    When I apply the filter "foobar" with "bazbat"
+    Then tearDown should not fail
+
+  Scenario: expectFilter fails when unmet
+    Given I expect the "foobar" filter with "bazbat"
+    When I do nothing
+    Then tearDown should fail
+
+  Scenario: expectFilter with extra arguments
+    Given I expect the "foobar" filter with:
+      | some | extra | data |
+    When I apply the filter "foobar" with:
+      | some | extra | data |
+    Then tearDown should not fail
+
+  Scenario: filter with the wrong arguments fails
+    Given I expect the "bazbat" filter with:
+      | the correct data |
+    When I apply the filter "bazbat" with:
+      | Invalid information |
+    Then tearDown should fail
+
+  Scenario: expectFilter fails when called with wrong argument
+    Given I expect the "foobar" filter with "bazbat"
+    When I apply the filter "foobar" with "bimbam"
+    Then tearDown should fail
+
+  Scenario: filter with extra arguments fails
+    Given I expect the "bazbat" filter with:
+      | data |
+    When I apply the filter "bazbat" with:
+      | data | plus |
+    Then tearDown should fail
+
   @strictmode
   Scenario: Unexpected action fails in strict mode
     Given strict mode is on

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -240,12 +240,13 @@ class WP_Mock {
 	 * in order to fulfill the expectation.
 	 *
 	 * @param string $filter
-	 * @param mixed $value
 	 */
-	public static function expectFilter( $filter, $value ) {
+	public static function expectFilter( $filter ) {
 		$intercept = \Mockery::mock( 'intercept' );
-		$intercept->shouldReceive( 'intercepted' )->atLeast()->once()->andReturn( $value );
-		$args = array_slice( func_get_args(), 1 );
+		$intercept->shouldReceive( 'intercepted' )->atLeast()->once()->andReturnUsing( function( $value ) {
+			return $value;
+		} );
+		$args = func_num_args() > 1 ? array_slice( func_get_args(), 1 ) : array( null );
 
 		$mocked_filter = self::onFilter( $filter );
 		$responder     = call_user_func_array( array( $mocked_filter, 'with' ), $args );

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -233,6 +233,25 @@ class WP_Mock {
 		$responder->perform( array( $intercept, 'intercepted' ) );
 	}
 
+	/**
+	 * Set up the expectation that a filter will be applied during the test.
+	 *
+	 * Mock a WordPress filter with specific arguments. You need all arguments that you expect
+	 * in order to fulfill the expectation.
+	 *
+	 * @param string $filter
+	 * @param mixed $value
+	 */
+	public static function expectFilter( $filter, $value ) {
+		$intercept = \Mockery::mock( 'intercept' );
+		$intercept->shouldReceive( 'intercepted' )->atLeast()->once()->andReturn( $value );
+		$args = array_slice( func_get_args(), 1 );
+
+		$mocked_filter = self::onFilter( $filter );
+		$responder     = call_user_func_array( array( $mocked_filter, 'with' ), $args );
+		$responder->reply( new \WP_Mock\InvokedFilterValue( array( $intercept, 'intercepted' ) ) );
+	}
+
 	public static function assertActionsCalled() {
 		if ( ! self::$event_manager->allActionsCalled() ) {
 			$failed = implode( ', ', self::$event_manager->expectedActions() );

--- a/php/WP_Mock/Filter.php
+++ b/php/WP_Mock/Filter.php
@@ -19,7 +19,7 @@ class Filter extends Hook {
 	 * @return mixed
 	 */
 	public function apply( $args ) {
-		if ( $args[0] === null ) {
+		if ( $args[0] === null && count( $args ) === 1 ) {
 			if ( isset( $this->processors['argsnull'] ) ) {
 				return $this->processors['argsnull']->send();
 			}
@@ -27,7 +27,6 @@ class Filter extends Hook {
 
 			return null;
 		}
-		$arg_num = count( $args );
 
 		$processors = $this->processors;
 		foreach ( $args as $arg ) {
@@ -41,7 +40,7 @@ class Filter extends Hook {
 			$processors = $processors[ $key ];
 		}
 
-		return $processors->send();
+		return call_user_func_array( array($processors, 'send'), $args );
 	}
 
 	protected function new_responder() {
@@ -68,7 +67,7 @@ class Filter_Responder {
 
 	public function send() {
 		if ( $this->value instanceof InvokedFilterValue ) {
-			return call_user_func( $this->value );
+			return call_user_func_array( $this->value, func_get_args() );
 		}
 
 		return $this->value;

--- a/php/WP_Mock/Filter.php
+++ b/php/WP_Mock/Filter.php
@@ -32,7 +32,7 @@ class Filter extends Hook {
 		$processors = $this->processors;
 		foreach ( $args as $arg ) {
 			$key = $this->safe_offset( $arg );
-			if ( ! isset( $processors[ $key ] ) ) {
+			if ( ! is_array( $processors ) || ! isset( $processors[ $key ] ) ) {
 				$this->strict_check();
 
 				return $arg;
@@ -67,6 +67,10 @@ class Filter_Responder {
 	}
 
 	public function send() {
+		if ( $this->value instanceof InvokedFilterValue ) {
+			return call_user_func( $this->value );
+		}
+
 		return $this->value;
 	}
 }

--- a/php/WP_Mock/InvokedFilterValue.php
+++ b/php/WP_Mock/InvokedFilterValue.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace WP_Mock;
+
+class InvokedFilterValue {
+
+	/**
+	 * @var callable
+	 */
+	protected $callback;
+
+	/**
+	 * InvokedFilterValue constructor.
+	 *
+	 * @param callable $callable
+	 */
+	public function __construct( $callable ) {
+		$this->callback = $callable;
+	}
+
+	public function __invoke() {
+		return call_user_func_array( $this->callback, func_get_args() );
+	}
+
+}


### PR DESCRIPTION
@leewillis77 recently opened #109 asking for a way to _assert_ that a filter was applied. He's right that, by default, you can change it, but it won't cause the test to fail if the filter is not applied. Yes, you can [enable strict mode](https://github.com/10up/wp_mock#strict-mode), which will cause those un-applied filters to fail, but that will also have many more side-effects that aren't intended.

Here's the feature request, implemented, with tests and documentation.