### PR TITLE
Added support for phpunit 6.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,26 +4,18 @@
 	"license"    : "GPL-2.0+",
 	"version"    : "0.2.0",
 	"require"    : {
-		"php"                 : ">=5.6",
-		"phpunit/phpunit"     : ">=4.3",
-		"mockery/mockery"     : "^0.9.5",
-		"antecedent/patchwork": "~2.0.3"
+		"php"                 : ">=7.0",
+		"phpunit/phpunit"     : ">=6.0",
+		"mockery/mockery"     : "^1.0",
+		"antecedent/patchwork": "^2.1"
 	},
 	"require-dev": {
 		"behat/behat"         : "^3.0",
 		"sebastian/comparator": ">=1.2.3"
 	},
-	"conflict": {
-		"phpunit/phpunit": ">=6.0"
-	},
 	"autoload"   : {
 		"psr-4"   : {"WP_Mock\\": "./php/WP_Mock"},
 		"classmap": ["php/WP_Mock.php"]
-	},
-	"config": {
-		"platform": {
-			"php": "5.6.0"
-		}
 	},
 	"scripts": {
 		"test:behat": "behat",

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -80,7 +80,7 @@ class FeatureContext implements Context, SnippetAcceptingContext {
 	public function teardownShouldFail() {
 		try {
 			$this->teardownShouldNotFail();
-			throw new PHPUnit_Framework_ExpectationFailedException( 'WP_Mock Teardown should have failed!' );
+			throw new \PHPUnit\Framework\ExpectationFailedException( 'WP_Mock Teardown should have failed!' );
 		} catch ( \Mockery\Exception\InvalidCountException $e ) {
 			// Move along
 		}

--- a/features/bootstrap/FunctionsContext.php
+++ b/features/bootstrap/FunctionsContext.php
@@ -10,7 +10,7 @@ class FunctionsContext implements Context {
 	 * @Given function :function does not exist
 	 */
 	public function functionDoesNotExist( $function ) {
-		PHPUnit_Framework_Assert::assertFalse( function_exists( $function ) );
+		\PHPUnit\Framework\Assert::assertFalse( function_exists( $function ) );
 	}
 
 	/**
@@ -48,7 +48,7 @@ class FunctionsContext implements Context {
 	 */
 	public function strictModeIsOn() {
 		FeatureContext::forceStrictModeOn();
-		PHPUnit_Framework_Assert::assertTrue( WP_Mock::strictMode() );
+		\PHPUnit\Framework\Assert::assertTrue( WP_Mock::strictMode() );
 	}
 
 	/**
@@ -56,7 +56,7 @@ class FunctionsContext implements Context {
 	 */
 	public function strictModeIsOff() {
 		FeatureContext::forceStrictModeOff();
-		PHPUnit_Framework_Assert::assertFalse( WP_Mock::strictMode() );
+		\PHPUnit\Framework\Assert::assertFalse( WP_Mock::strictMode() );
 	}
 
 	/**
@@ -77,14 +77,14 @@ class FunctionsContext implements Context {
 	 * @Then function :function should exist
 	 */
 	public function functionShouldExist( $function ) {
-		PHPUnit_Framework_Assert::assertTrue( function_exists( $function ) );
+		\PHPUnit\Framework\Assert::assertTrue( function_exists( $function ) );
 	}
 
 	/**
 	 * @Then I expect :return when I run :function with args:
 	 */
 	public function iExpectWhenIRunWithArgs( $return, $function, TableNode $args ) {
-		PHPUnit_Framework_Assert::assertEquals( $return, call_user_func_array( $function, $args->getRow( 0 ) ) );
+		\PHPUnit\Framework\Assert::assertEquals( $return, call_user_func_array( $function, $args->getRow( 0 ) ) );
 	}
 
 	/**
@@ -102,7 +102,7 @@ class FunctionsContext implements Context {
 			$this->iExpectWhenIRunWithArgs( null, $function, $args );
 		} catch ( NoMatchingExpectationException $e ) {
 			// Move along...
-		} catch ( \PHPUnit_Framework_ExpectationFailedException $e ) {
+		} catch ( \PHPUnit\Framework\ExpectationFailedException $e ) {
 			// Move along...
 		}
 	}
@@ -114,7 +114,7 @@ class FunctionsContext implements Context {
 		ob_start();
 		$function( $input );
 		$output = trim( ob_get_clean() );
-		PHPUnit_Framework_Assert::assertEquals( trim( $input ), $output );
+		\PHPUnit\Framework\Assert::assertEquals( trim( $input ), $output );
 	}
 
 	/**

--- a/features/bootstrap/HooksContext.php
+++ b/features/bootstrap/HooksContext.php
@@ -196,8 +196,8 @@ class HooksContext implements Context {
 	 * @Then The filter :filter should return :value
 	 */
 	public function theFilterShouldReturn( $filter, $value ) {
-		PHPUnit_Framework_Assert::assertArrayHasKey( $filter, $this->filterResults );
-		PHPUnit_Framework_Assert::assertEquals( $this->filterResults[ $filter ], $value );
+		\PHPUnit\Framework\Assert::assertArrayHasKey( $filter, $this->filterResults );
+		\PHPUnit\Framework\Assert::assertEquals( $this->filterResults[ $filter ], $value );
 	}
 
 	private function getActionsWithDefaults( TableNode $table ) {

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -256,7 +256,7 @@ class WP_Mock {
 	public static function assertActionsCalled() {
 		if ( ! self::$event_manager->allActionsCalled() ) {
 			$failed = implode( ', ', self::$event_manager->expectedActions() );
-			throw new PHPUnit_Framework_ExpectationFailedException( 'Method failed to invoke actions: ' . $failed, null );
+			throw new \PHPUnit\Framework\ExpectationFailedException( 'Method failed to invoke actions: ' . $failed, null );
 		}
 	}
 
@@ -350,7 +350,7 @@ class WP_Mock {
 	public static function assertHooksAdded() {
 		if ( ! self:: $event_manager->allHooksAdded() ) {
 			$failed = implode( ', ', self::$event_manager->expectedHooks() );
-			throw new PHPUnit_Framework_ExpectationFailedException( 'Method failed to add hooks: ' . $failed, null );
+			throw new \PHPUnit\Framework\ExpectationFailedException( 'Method failed to add hooks: ' . $failed, null );
 		}
 	}
 

--- a/php/WP_Mock/DeprecatedListener.php
+++ b/php/WP_Mock/DeprecatedListener.php
@@ -2,19 +2,19 @@
 
 namespace WP_Mock;
 
-use PHPUnit_Framework_TestCase;
+use \PHPUnit\Framework\TestCase;
 
 class DeprecatedListener {
 
 	protected $calls = array();
 
-	/** @var \PHPUnit_Framework_TestResult */
+	/** @var \PHPUnit\Framework\TestCase */
 	protected $testResult;
 
 	protected $testName;
 
 	/**
-	 * @var PHPUnit_Framework_TestCase
+	 * @var \PHPUnit\Framework\TestCase
 	 */
 	protected $testCase;
 
@@ -30,12 +30,12 @@ class DeprecatedListener {
 		if ( empty( $this->calls ) ) {
 			return;
 		}
-		$e = new \PHPUnit_Framework_RiskyTestError( $this->getMessage() );
+		$e = new \PHPUnit\Framework\RiskyTestError( $this->getMessage() );
 		$this->testResult->addFailure( $this->testCase, $e, 0 );
 	}
 
 	/**
-	 * @param \PHPUnit_Framework_TestResult $testResult
+	 * @param \PHPUnit\Framework\TestResult $testResult
 	 */
 	public function setTestResult( $testResult ) {
 		$this->testResult = $testResult;
@@ -48,7 +48,7 @@ class DeprecatedListener {
 		$this->testName = $testName;
 	}
 
-	public function setTestCase( PHPUnit_Framework_TestCase $testCase ) {
+	public function setTestCase( \PHPUnit\Framework\TestCase $testCase ) {
 		$this->testCase = $testCase;
 	}
 

--- a/php/WP_Mock/Handler.php
+++ b/php/WP_Mock/Handler.php
@@ -42,7 +42,7 @@ class Handler {
 
 			return call_user_func_array( $callback, $args );
 		} elseif ( \WP_Mock::strictMode() ) {
-			throw new \PHPUnit_Framework_ExpectationFailedException(
+			throw new \PHPUnit\Framework\ExpectationFailedException(
 				sprintf( 'No handler found for %s', $function_name )
 			);
 		}

--- a/php/WP_Mock/Hook.php
+++ b/php/WP_Mock/Hook.php
@@ -72,11 +72,11 @@ abstract class Hook {
 	/**
 	 * Throw an exception if strict mode is on
 	 *
-	 * @throws \PHPUnit_Framework_ExpectationFailedException
+	 * @throws \PHPUnit\Framework\ExpectationFailedException
 	 */
 	protected function strict_check() {
 		if ( \WP_Mock::strictMode() ) {
-			throw new \PHPUnit_Framework_ExpectationFailedException( $this->get_strict_mode_message() );
+			throw new \PHPUnit\Framework\ExpectationFailedException( $this->get_strict_mode_message() );
 		}
 	}
 

--- a/php/WP_Mock/Tools/Constraints/ExpectationsMet.php
+++ b/php/WP_Mock/Tools/Constraints/ExpectationsMet.php
@@ -2,11 +2,11 @@
 
 namespace WP_Mock\Tools\Constraints;
 
-use PHPUnit_Framework_Constraint;
+use PHPUnit\Framework\Constraint\Constraint;
 use Mockery;
 use Exception;
 
-class ExpectationsMet extends PHPUnit_Framework_Constraint {
+class ExpectationsMet extends \PHPUnit\Framework\Constraint\Constraint {
 
 	private $_mockery_message;
 

--- a/php/WP_Mock/Tools/Constraints/IsEqualHtml.php
+++ b/php/WP_Mock/Tools/Constraints/IsEqualHtml.php
@@ -2,9 +2,9 @@
 
 namespace WP_Mock\Tools\Constraints;
 
-use PHPUnit_Framework_Constraint_IsEqual;
+use PHPUnit\Framework\Constraint\IsEqual;
 
-class IsEqualHtml extends PHPUnit_Framework_Constraint_IsEqual {
+class IsEqualHtml extends \PHPUnit\Framework\Constraint\IsEqual {
 
 	private function clean( $thing ) {
 		$thing = preg_replace( '/\n\s+/', '', $thing );

--- a/php/WP_Mock/Tools/TestCase.php
+++ b/php/WP_Mock/Tools/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace WP_Mock\Tools;
 
-use PHPUnit_Framework_TestResult;
+use PHPUnit\Framework\TestResult;
 use Exception;
 use Mockery;
 use ReflectionMethod;
@@ -11,7 +11,7 @@ use WP_Mock;
 use WP_Mock\Tools\Constraints\ExpectationsMet;
 use WP_Mock\Tools\Constraints\IsEqualHtml;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase {
+abstract class TestCase extends \PHPUnit\Framework\TestCase {
 
 	protected $mockedStaticMethods = array();
 
@@ -296,7 +296,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase {
 		}
 	}
 
-	public function run( PHPUnit_Framework_TestResult $result = null ) {
+	public function run( \PHPUnit\Framework\TestResult $result = null ) {
 		if ( $result === null ) {
 			$result = $this->createResult();
 		}

--- a/tests/DeprecatedMethodsTest.php
+++ b/tests/DeprecatedMethodsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class DeprecatedMethodsTest extends PHPUnit_Framework_TestCase {
+class DeprecatedMethodsTest extends \PHPUnit\Framework\TestCase {
 
 	public function setUp() {
 		WP_Mock::setUp();
@@ -14,26 +14,26 @@ class DeprecatedMethodsTest extends PHPUnit_Framework_TestCase {
 
 	public function testWpFunctionLogsDeprecationNotice() {
 		$listener = WP_Mock::getDeprecatedListener();
-		$result   = Mockery::mock( 'PHPUnit_Framework_TestResult' );
-		$case     = Mockery::mock( 'PHPUnit_Framework_TestCase' );
+		$result   = Mockery::mock( '\PHPUnit\Framework\TestResult' );
+		$case     = Mockery::mock( '\PHPUnit\Framework\TestCase' );
 		$listener->setTestCase( $case );
 		$listener->setTestResult( $result );
 		$result->shouldReceive( 'addFailure' )
 			->once()
-			->with( $case, Mockery::type( 'PHPUnit_Framework_RiskyTestError' ), 0 );
+			->with( $case, Mockery::type( '\PHPUnit\Framework\RiskyTestError' ), 0 );
 		WP_Mock::wpFunction( 'foobar' );
 		$listener->checkCalls();
 	}
 
 	public function testWpPassthruFunctionLogsDeprecationNotice() {
 		$listener = WP_Mock::getDeprecatedListener();
-		$result   = Mockery::mock( 'PHPUnit_Framework_TestResult' );
-		$case     = Mockery::mock( 'PHPUnit_Framework_TestCase' );
+		$result   = Mockery::mock( '\PHPUnit\Framework\TestResult' );
+		$case     = Mockery::mock( '\PHPUnit\Framework\TestCase' );
 		$listener->setTestCase( $case );
 		$listener->setTestResult( $result );
 		$result->shouldReceive( 'addFailure' )
 			->once()
-			->with( $case, Mockery::type( 'PHPUnit_Framework_RiskyTestError' ), 0 );
+			->with( $case, Mockery::type( '\PHPUnit\Framework\RiskyTestError' ), 0 );
 		WP_Mock::wpPassthruFunction( 'foobar' );
 		$listener->checkCalls();
 	}

--- a/tests/FunctionMocksTest.php
+++ b/tests/FunctionMocksTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class FunctionMocksTest extends PHPUnit_Framework_TestCase {
+class FunctionMocksTest extends \PHPUnit\Framework\TestCase {
 
 	private $common_functions = array(
 		'esc_attr',
@@ -56,7 +56,7 @@ class FunctionMocksTest extends PHPUnit_Framework_TestCase {
 	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
-	 * @expectedException PHPUnit_Framework_ExpectationFailedException
+	 * @expectedException \PHPUnit\Framework\ExpectationFailedException
 	 * @expectedExceptionMessageRegExp /No handler found for \w+/
 	 */
 	public function testDefaultFailsInStrictMode() {

--- a/tests/WP_Mock/DeprecatedListenerTest.php
+++ b/tests/WP_Mock/DeprecatedListenerTest.php
@@ -3,12 +3,12 @@
 namespace WP_Mock;
 
 use Mockery;
-use PHPUnit_Framework_Assert;
-use PHPUnit_Framework_RiskyTest;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\RiskyTest;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 
-class DeprecatedListenerTest extends PHPUnit_Framework_TestCase {
+class DeprecatedListenerTest extends \PHPUnit\Framework\TestCase {
 
 	/** @var DeprecatedListener */
 	protected $object;
@@ -37,9 +37,9 @@ class DeprecatedListenerTest extends PHPUnit_Framework_TestCase {
 	}
 
 	public function testCheckCallsNoCalls() {
-		$result = Mockery::mock( 'PHPUnit_Framework_TestResult' );
+		$result = Mockery::mock( '\PHPUnit\Framework\TestResult' );
 		$result->shouldReceive( 'addFailure' )->never();
-		/** @var \PHPUnit_Framework_TestResult $result */
+		/** @var \\PHPUnit\Framework\TestResult $result */
 		$this->object->setTestResult( $result );
 
 		$this->object->checkCalls();
@@ -48,23 +48,23 @@ class DeprecatedListenerTest extends PHPUnit_Framework_TestCase {
 	public function testCheckCalls_scalar_only() {
 		$this->object->logDeprecatedCall( 'FooBar::bazBat', array( 'string', true, 42 ) );
 		$this->object->setTestName( 'TestName' );
-		$testCase = Mockery::mock( 'PHPUnit_Framework_TestCase' );
-		/** @var PHPUnit_Framework_TestCase $testCase */
+		$testCase = Mockery::mock( '\PHPUnit\Framework\TestCase' );
+		/** @var \PHPUnit\Framework\TestCase $testCase */
 		$this->object->setTestCase( $testCase );
-		$result = Mockery::mock( 'PHPUnit_Framework_TestResult' );
+		$result = Mockery::mock( '\PHPUnit\Framework\TestResult' );
 		$result->shouldReceive( 'addFailure' )
 			->once()
 			->andReturnUsing( function ( $case, $exception, $int ) use ( $testCase ) {
-				PHPUnit_Framework_Assert::assertSame( $testCase, $case );
-				PHPUnit_Framework_Assert::assertTrue( $exception instanceof PHPUnit_Framework_RiskyTest );
+				\PHPUnit\Framework\Assert::assertSame( $testCase, $case );
+				\PHPUnit\Framework\Assert::assertTrue( $exception instanceof \PHPUnit\Framework\RiskyTest );
 				$message = <<<EOT
 Deprecated WP Mock calls inside TestName:
   FooBar::bazBat ["string",true,42]
 EOT;
-				PHPUnit_Framework_Assert::assertEquals( $message, $exception->getMessage() );
-				PHPUnit_Framework_Assert::assertTrue( 0 === $int );
+				\PHPUnit\Framework\Assert::assertEquals( $message, $exception->getMessage() );
+				\PHPUnit\Framework\Assert::assertTrue( 0 === $int );
 			} );
-		/** @var \PHPUnit_Framework_TestResult $result */
+		/** @var \\PHPUnit\Framework\TestResult $result */
 		$this->object->setTestResult( $result );
 
 		$this->object->checkCalls();
@@ -81,15 +81,15 @@ EOT;
 		$this->object->logDeprecatedCall( 'LongerClassName::callback', array( array( $object1, 'shouldReceive' ) ) );
 		$this->object->logDeprecatedCall( 'BazBat::fooBar', array( range( 1, $range ), $resource ) );
 		$this->object->setTestName( 'OtherTest' );
-		$testCase = Mockery::mock( 'PHPUnit_Framework_TestCase' );
-		/** @var PHPUnit_Framework_TestCase $testCase */
+		$testCase = Mockery::mock( '\PHPUnit\Framework\TestCase' );
+		/** @var \PHPUnit\Framework\TestCase $testCase */
 		$this->object->setTestCase( $testCase );
-		$result      = Mockery::mock( 'PHPUnit_Framework_TestResult' );
+		$result      = Mockery::mock( '\PHPUnit\Framework\TestResult' );
 		$testClosure = function ( $case, $exception, $int ) use ( $testCase, $callback1, $object1, $range ) {
 			$callback1 = get_class( $callback1 ) . ':' . spl_object_hash( $callback1 );
 			$object1   = get_class( $object1 ) . ':' . spl_object_hash( $object1 );
-			PHPUnit_Framework_Assert::assertSame( $testCase, $case );
-			PHPUnit_Framework_Assert::assertTrue( $exception instanceof PHPUnit_Framework_RiskyTest );
+			\PHPUnit\Framework\Assert::assertSame( $testCase, $case );
+			\PHPUnit\Framework\Assert::assertTrue( $exception instanceof \PHPUnit\Framework\RiskyTest );
 			$message = <<<EOT
 Deprecated WP Mock calls inside OtherTest:
   BazBat::fooBar            ["<$callback1>"]
@@ -97,13 +97,13 @@ Deprecated WP Mock calls inside OtherTest:
                             ["Array([$range] ...)","Resource"]
   LongerClassName::callback ["[<$object1>,shouldReceive]"]
 EOT;
-			PHPUnit_Framework_Assert::assertEquals( $message, $exception->getMessage() );
-			PHPUnit_Framework_Assert::assertTrue( 0 === $int );
+			\PHPUnit\Framework\Assert::assertEquals( $message, $exception->getMessage() );
+			\PHPUnit\Framework\Assert::assertTrue( 0 === $int );
 		};
 		$result->shouldReceive( 'addFailure' )
 			->once()
 			->andReturnUsing( $testClosure );
-		/** @var \PHPUnit_Framework_TestResult $result */
+		/** @var \\PHPUnit\Framework\TestResult $result */
 		$this->object->setTestResult( $result );
 
 		try {

--- a/tests/WP_MockTest.php
+++ b/tests/WP_MockTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class WP_MockTest extends PHPUnit_Framework_TestCase {
+class WP_MockTest extends \PHPUnit\Framework\TestCase {
 
 	/**
 	 * @runInSeparateProcess


### PR DESCRIPTION
I have made the following changes.

- Updated all legacy `PHPUnit_Framework_*` classes to their corresponding namespaced classes
- Added phpunit 6.0 or above as requirement in composer.json and removed conflict block for phpunit 6.0+
- Updated PHP requirement to 7.0+ since it is required by phpunit 6.0+
- All tests are passing

Fixes #88 