### PR TITLE
#89 support anonymous function hooks

### DIFF
--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -327,6 +327,7 @@ class WP_Mock {
 		$responder = self::onHookAdded( $action, $type )
 			->with( $callback, $priority, $args );
 		$responder->perform( array( $intercept, 'intercepted' ) );
+		$responder->react();
 	}
 
 	/**

--- a/tests/DeprecatedMethodsTest.php
+++ b/tests/DeprecatedMethodsTest.php
@@ -22,7 +22,10 @@ class DeprecatedMethodsTest extends \PHPUnit\Framework\TestCase {
 			->once()
 			->with( $case, Mockery::type( '\PHPUnit\Framework\RiskyTestError' ), 0 );
 		WP_Mock::wpFunction( 'foobar' );
-		$listener->checkCalls();
+
+		// The meaningful assertion is the shouldReceive() above,
+		// here we just want to stop PHPUnit from complaining.
+		$this->assertNull($listener->checkCalls());
 	}
 
 	public function testWpPassthruFunctionLogsDeprecationNotice() {
@@ -35,7 +38,10 @@ class DeprecatedMethodsTest extends \PHPUnit\Framework\TestCase {
 			->once()
 			->with( $case, Mockery::type( '\PHPUnit\Framework\RiskyTestError' ), 0 );
 		WP_Mock::wpPassthruFunction( 'foobar' );
-		$listener->checkCalls();
+
+		// The meaningful assertion is the shouldReceive() above,
+		// here we just want to stop PHPUnit from complaining.
+		$this->assertNull($listener->checkCalls());
 	}
 
 }

--- a/tests/WP_Mock/DeprecatedListenerTest.php
+++ b/tests/WP_Mock/DeprecatedListenerTest.php
@@ -42,7 +42,9 @@ class DeprecatedListenerTest extends \PHPUnit\Framework\TestCase {
 		/** @var \\PHPUnit\Framework\TestResult $result */
 		$this->object->setTestResult( $result );
 
-		$this->object->checkCalls();
+		// The meaningful assertion is really that addFailure() is never called
+		// (above), but here we just want to stop PHPUnit from complaining.
+		$this->assertNull($this->object->checkCalls());
 	}
 
 	public function testCheckCalls_scalar_only() {
@@ -62,7 +64,7 @@ Deprecated WP Mock calls inside TestName:
   FooBar::bazBat ["string",true,42]
 EOT;
 				\PHPUnit\Framework\Assert::assertEquals( $message, $exception->getMessage() );
-				\PHPUnit\Framework\Assert::assertTrue( 0 === $int );
+				\PHPUnit\Framework\Assert::assertTrue( 0.0 === $int );
 			} );
 		/** @var \\PHPUnit\Framework\TestResult $result */
 		$this->object->setTestResult( $result );
@@ -98,7 +100,7 @@ Deprecated WP Mock calls inside OtherTest:
   LongerClassName::callback ["[<$object1>,shouldReceive]"]
 EOT;
 			\PHPUnit\Framework\Assert::assertEquals( $message, $exception->getMessage() );
-			\PHPUnit\Framework\Assert::assertTrue( 0 === $int );
+			\PHPUnit\Framework\Assert::assertTrue( 0.0 === $int );
 		};
 		$result->shouldReceive( 'addFailure' )
 			->once()


### PR DESCRIPTION
It's been a while since I looked at this, but this is still an issue for me and I've made a PoC repo [here](https://github.com/acobster/wp-mock-poc).

Don't know that almost a year after promising this PR counts as "soon," buuuut ;)