### PR TITLE
Update readme's examples of setUp() and tearDown() methods with PHP 7 return type declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Finally, register calls inside your test class to instantiate and clean up the `
 
 ```php
 class MyTestClass extends \WP_Mock\Tools\TestCase {
-	public function setUp() {
+	public function setUp(): void {
 		\WP_Mock::setUp();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		\WP_Mock::tearDown();
 	}
 }
@@ -84,11 +84,11 @@ Write your tests as you normally would. If you desire specific responses from Wo
 
 ```php
 class MyTestClass extends \WP_Mock\Tools\TestCase {
-	public function setUp() {
+	public function setUp(): void {
 		\WP_Mock::setUp();
 	}
 
-	public function tearDown() {
+	public function tearDown(): void {
 		\WP_Mock::tearDown();
 	}
 


### PR DESCRIPTION
<!--
### Requirements

Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.  All new code requires documentation and tests to ensure against regressions.
-->

### Description of the Change
I added return type declarations to the setUp() and tearDown() methods in the readme's code examples as I suggested in this issue: #141 . This is the change I had to make to my own tests in a different project after upgrading to PHP7, PHPUnit 8, and WP_Mock 0.4.2 

### Benefits
It might help people get up and running a little bit faster if they don't encounter any errors when trying to run their first tests.

### Possible Drawbacks

### Verification Process
I previewed the readme and used these function declarations in my own tests in a different repo after upgrading to PHP7, PHPUnit 8, and WP_Mock 0.4.2

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Applicable Issues
#141 
<!-- Enter any applicable Issues here -->
