### PR TITLE
Updated installation instructions to emphasize the requirement of a bootstrap.php file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,12 @@
 
 ## Table of Contents
 * [Installation](#installation)
-* [Bootstrapping WP_Mock](#bootstrapping-wp_mock)
+  * [Bootstrapping WP_Mock](#bootstrapping-wp_mock)
   * [Strict Mode](#strict-mode)
 * [Using WP_Mock](#using-wp_mock)
   * [Mocking WordPress core functions](#mocking-wordpress-core-functions)
   * [Using Mockery expectations](#using-mockery-expectations)
   * [Passthru functions](#passthru-functions)
-  * [Running Locally](#running-locally)
   * [Deprecated methods](#deprecated-methods)
   * [Mocking actions and filters](#mocking-actions-and-filters)
   * [Mocking WordPress objects](#mocking-wordpress-objects)
@@ -47,17 +46,20 @@ class MyTestClass extends \WP_Mock\Tools\TestCase {
 }
 ```
 
-## Bootstrapping WP_Mock
+### Bootstrapping WP_Mock
 
-Before you can start using WP_Mock to test your code, you'll need to bootstrap the library. The easiest way is to use a bootstrap file. See the PHPUnit documentation for how to define a bootstrap script either [from the command line](https://phpunit.de/manual/current/en/textui.html#textui.clioptions) or [from the xml config file](https://phpunit.de/manual/current/en/appendixes.configuration.html). Here is an example of a bootstrap you might use:
+#### bootstrap.php
+Before you can start using WP_Mock to test your code, you'll need to bootstrap the library by creating a `bootstrap.php` file. 
+
+Here is an example of a bootstrap you might use:
 
 ```php
 <?php
 
-// First we need to load the composer autoloader so we can use WP Mock
+// First we need to load the composer autoloader, so we can use WP Mock
 require_once __DIR__ . '/vendor/autoload.php';
 
-// Now call the bootstrap method of WP Mock
+// Bootstrap WP_Mock to initialize built-in features
 WP_Mock::bootstrap();
 
 /**
@@ -69,9 +71,30 @@ require_once __DIR__ . '/plugin.php';
 
 The bootstrap method does a few things:
 
-- Defines action and filter functions
-- Defines some common WordPress constants
-- Sets up Patchwork if it has been turned on
+- Bootstraps `WP_Mock` which defines action and filter functions, as well as common WordPress constants
+- Sets up Patchwork if it has been turned on ([see below](#patchwork))
+- Include any custom files you need to run the test.
+
+
+#### Using bootstrap.php
+
+**CLI**
+
+Run `phpunit` with the `--bootstrap` flag (see [documentation]()):
+```bash
+./vendor/bin/phpunit --bootstrap /path/to/bootstrap.php
+```
+
+**phpunit.xml**
+
+Add the following to `phpunit.xml` (see [documentation](https://phpunit.de/manual/current/en/appendixes.configuration.html).):
+```
+bootstrap="/path/to/bootstrap.php"
+```
+
+#### Patchwork
+
+[Patchwork](https://github.com/antecedent/patchwork) is a library that enables temporarily overwriting user-defined functions and static methods. This means you can better isolate your system under test by mocking your plugin's functions that are tested elsewhere. If Patchwork is turned on, WP_Mock will transparently use it behind the scenes. For most use cases, you won't need to worry about using it directly.
 
 If you'd like to use Patchwork in your tests, you need to specifically turn it on before bootstrapping WP_Mock:
 
@@ -79,8 +102,6 @@ If you'd like to use Patchwork in your tests, you need to specifically turn it o
 WP_Mock::setUsePatchwork( true );
 WP_Mock::bootstrap();
 ```
-
-Patchwork is a library that enables temporarily overwriting user-defined functions and static methods. This means you can better isolate your system under test by mocking your plugin's functions that are tested elsewhere. If Patchwork is turned on, WP_Mock will transparently use it behind the scenes. For most use cases, you won't need to worry about using it directly.
 
 ### Strict Mode
 


### PR DESCRIPTION
This PR updates README.md to make it clear that setting up a `bootstrap.php` is a required part of the installation process.

### Description of the Change

Issues linked below seem to be caused by excluding `WP_Mock::bootstrap()`. With the current version of the documentation it can be easy to skip past the requirement to include bootstrap. 

This PR also adds examples of using the `bootstrap.php` file and additional minor layout tweaks.

<!-- Enter any applicable Issue number(s) here that will be closed/resolved by this PR. -->
Closes #128, closes #147 

### How to test the Change
<!-- Please provide steps on how to test or validate that the change in this PR works as described. -->
N/A

### Changelog Entry
<!--
Please include a summary for this PR, noting whether this is something being Added / Changed / Deprecated / Removed / Fixed / or Security related.  You can replace the sample entries after this comment block with the single changelog entry line for this PR. -->

- Updated README.md

### Checklist:
 - [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change. 
- [x] All new and existing tests pass.
