### PR TITLE
Send test coverage reports to Coveralls via GitHub workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,4 +77,4 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          vendor/bin/php-coveralls --coverage_clover="./clover.xml" -v
+          vendor/bin/php-coveralls --coverage_clover="./clover.xml" --json_path="./coveralls-upload.json" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,37 +72,10 @@ jobs:
         run: |
           vendor/bin/phpunit --order-by="random" --coverage-cache="$COVERAGE_CACHE_PATH" --coverage-cobertura=./cobertura.xml --coverage-clover=./clover.xml --coverage-text
 
-      # TODO decide later if to keep using Coveralls
-      #- name: Upload coverage results to Coveralls
-      #  if: ${{ env.PHP_VERSION == '8.1' }}
-      #  run: |
-      #    vendor/bin/php-coveralls --coverage_clover="./clover.xml" --json_path="./coveralls-upload.json" -v
-
-      - name: Generate code coverage summary
-        # https://github.com/irongut/CodeCoverageSummary
-        uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
+      - name: Upload test coverage results to Coveralls
         if: ${{ env.PHP_VERSION == '8.1' }}
-        with:
-          filename: "./cobertura.xml"
-          badge: true
-          format: markdown
-          fail_below_min: false
-          hide_branch_rate: true
-          hide_complexity: true
-          indicators: false
-          output: file
-
-      - name: Grab code coverage badge
-        if: ${{ env.PHP_VERSION == '8.1' && github.event_name == 'pull_request'}}
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          head -1 ./code-coverage-results.md > ./code-coverage-badge.md
-          cat ./code-coverage-badge.md
-
-      - name: Add or update comment to PR with coverage results
-        # https://github.com/marocchino/sticky-pull-request-comment
-        uses: marocchino/sticky-pull-request-comment@39c5b5dc7717447d0cba270cd115037d32d28443 # v2.2.0
-        if: ${{ env.PHP_VERSION == '8.1' && github.event_name == 'pull_request'}}
-        with:
-          header: code-coverage-badge
-          recreate: true
-          path: ./code-coverage-badge.md
+          composer global require php-coveralls/php-coveralls
+          php-coveralls --coverage_clover="./clover.xml" -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         # Otherwise, current coverage can be viewed in the action output.
         # Tests should be run randomly to catch any test dependency issue.
         run: |
-          vendor/bin/phpunit --order-by="random" --coverage-cache="$COVERAGE_CACHE_PATH" --coverage-cobertura=./cobertura.xml --coverage-clover=./clover.xml --coverage-text
+          vendor/bin/phpunit --order-by="random" --coverage-cache="$COVERAGE_CACHE_PATH" --coverage-clover=./clover.xml --coverage-text
 
       - name: Upload test coverage results to Coveralls
         if: ${{ env.PHP_VERSION == '8.1' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,5 +77,4 @@ jobs:
         env:
           COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          composer global require php-coveralls/php-coveralls
-          php-coveralls --coverage_clover="./clover.xml" -v
+          vendor/bin/php-coveralls --coverage_clover="./clover.xml" -v


### PR DESCRIPTION
### Description of the Change

This PR restores support for Coveralls via GitHub action workflow / PHP-Coveralls library.

Removes test coverage badge statically generated by reading test report from PHPUnit.

### How to test the Change

- [ ] Tests coverage should be submitted to Coveralls (should be available at https://coveralls.io/builds/52570496 for this branch)
- [ ] The action will also produce results when the changes come from a fork (for example: https://github.com/10up/wp_mock/pull/169)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification.  We are here to help! -->
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly. _n/a_
- [ ] I have added tests to cover my change. _n/a_
- [x] All new and existing tests pass.
