### PR TITLE
Readme improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ function test_get_post_ids() {
 
 ## Changelog
 
-A complete listing of all notable changes to WP_Mock are documented in [CHANGELOG.md](https://github.com/10up/wp_mock/blob/develop/CHANGELOG.md).
+A complete listing of all notable changes to WP_Mock are documented in [CHANGELOG.md](https://github.com/10up/wp_mock/blob/trunk/CHANGELOG.md).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ A complete listing of all notable changes to WP_Mock are documented in [CHANGELO
 
 ## Contributing
 
-Please read [CODE_OF_CONDUCT.md](https://github.com/10up/wp_mock/blob/trunk/CODE_OF_CONDUCT.md) for details on our code of conduct, [CONTRIBUTING.md](https://github.com/10up/wp_mock/blob/trunk/CONTRIBUTING.md) for details on the process for submitting pull requests to us, and [CREDITS.md](https://github.com/10up/wp_mock/blob/trunk/CREDITS.md) for a listing of maintainers of, contributors to, and libraries used by Apple Maps for WordPress.
+Please read [CODE_OF_CONDUCT.md](https://github.com/10up/wp_mock/blob/trunk/CODE_OF_CONDUCT.md) for details on our code of conduct, [CONTRIBUTING.md](https://github.com/10up/wp_mock/blob/trunk/CONTRIBUTING.md) for details on the process for submitting pull requests to us, and [CREDITS.md](https://github.com/10up/wp_mock/blob/trunk/CREDITS.md) for a listing of maintainers of, contributors to, and libraries used by WP_Mock.
 
 ## Like what you see?
 

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ A complete listing of all notable changes to WP_Mock are documented in [CHANGELO
 
 ## Contributing
 
-Please read [CODE_OF_CONDUCT.md](https://github.com/10up/wp_mock/blob/develop/CODE_OF_CONDUCT.md) for details on our code of conduct, [CONTRIBUTING.md](https://github.com/10up/wp_mock/blob/develop/CONTRIBUTING.md) for details on the process for submitting pull requests to us, and [CREDITS.md](https://github.com/10up/wp_mock/blob/develop/CREDITS.md) for a listing of maintainers of, contributors to, and libraries used by Apple Maps for WordPress.
+Please read [CODE_OF_CONDUCT.md](https://github.com/10up/wp_mock/blob/trunk/CODE_OF_CONDUCT.md) for details on our code of conduct, [CONTRIBUTING.md](https://github.com/10up/wp_mock/blob/trunk/CONTRIBUTING.md) for details on the process for submitting pull requests to us, and [CREDITS.md](https://github.com/10up/wp_mock/blob/trunk/CREDITS.md) for a listing of maintainers of, contributors to, and libraries used by Apple Maps for WordPress.
 
 ## Like what you see?
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
   * [Deprecated methods](#deprecated-methods)
   * [Mocking actions and filters](#mocking-actions-and-filters)
   * [Mocking WordPress objects](#mocking-wordpress-objects)
+  * [Mocking constants](#mocking-constants)
 * [Changelog](#changelog)
 * [Contributing](#contributing)
 
@@ -423,6 +424,37 @@ function test_get_post_ids() {
 	$this->assertEquals( array( 1, 2, 3 ), $post_ids );
 }
 ```
+
+### Mocking constants
+
+Certain constants need to be mocked, otherwise various WordPress functions will attempt to include files that just don't exist.
+
+For example, nearly all uses of the `WP_Http` API require first including:
+
+```
+ABSPATH . WPINC . '/class-http.php'
+```
+
+If these constants are not set, and files do not exist at the location they specify, functions referencing them will fatally err.
+
+By default, WP_Mock will [mock the following constants](./php/WP_Mock/API/constant-mocks.php):
+
+| Constant         | Default mocked value                   |
+|------------------|----------------------------------------|
+| `WP_CONTENT_DIR` | `__DIR__ . '/dummy-files'`             |
+| `ABSPATH`        | `''`                                   |
+| `WPINC`          | `__DIR__ . '/dummy-files/wp-includes'` |
+| `EZSQL_VERSION`  | `'WP1.25'`                             |
+| `OBJECT`         | `'OBJECT'`                             |
+| `Object`         | `'OBJECT'`                             |
+| `object`         | `'OBJECT'`                             |
+| `OBJECT_K`       | `'OBJECT_K'`                           |
+| `ARRAY_A`        | `'ARRAY_A'`                            |
+| `ARRAY_N`        | `'ARRAY_N'`                            |
+
+WP_Mock provides a few dummy files, located in the `./php/WP_Mock/API/dummy-files/` directory. These files are used to mock the `WP_CONTENT_DIR` and `WPINC` constants, as shown in the table above.
+
+The `! defined` check is used for all constants, so that individual test environments can override the normal default by setting constants in a bootstrap configuration file.
 
 ## Support Level
 


### PR DESCRIPTION
### Description of the Change

Updated `README` to:

- Fix broken links to `CHANGELOG`, `CODE_OF_CONDUCT`, `CONTRIBUTING`, and `CREDITS` (they used to point to the non-existent `develop` branch)
- Replace `used by Apple Maps for WordPress` to `used by WP_Mock`, under the **Contributing** section (probably accidentally copied from the [Block for Apple Maps](https://github.com/10up/maps-block-apple) repo)
- Add **Mocking constants** section, explaining why certain constants need to be mocked, where to find WP_Mock's dummy files and how to override these mocked values by setting constants in a bootstrap configuration file (heavily based on [this comment](https://github.com/10up/wp_mock/blob/trunk/php/WP_Mock/API/constant-mocks.php#L2-L14))

### How to test the Change

N/A

### Changelog Entry

> Updated `README`

### Credits

@over-engineer

### Checklist:
- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly.
- [x] ~~I have added tests to cover my change.~~ (N/A)
- [x] ~~All new and existing tests pass.~~ (N/A)
