### PR TITLE
#89 support closures/anonymous functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,20 @@ public function test_special_function() {
 
 It's important to note that the `$priority` and `$parameter_count` arguments (parameters 3 and 4 for both `add_action()` and `add_filter()`) are significant. If `special_function()` were to call `add_action( 'save_post', 'special_save_post', 99, 3 )` instead of the expected `add_action( 'save_post', 'special_save_post', 10, 2 )`, our test would fail.
 
+#### Asserting that Closure hooks have been added
+
+Sometimes it's handy to add a [Closure](https://secure.php.net/manual/en/class.closure.php) as a WordPress hook instead of defining a function in the global namespace. To assert that such a hook has been added, you can use the special `closure` type:
+
+```php
+public function test_anonymous_function_hook() {
+	\WP_Mock::expectActionAdded( 'save_post', \WP_Mock\Functions::type( 'closure' ) );
+	\WP_Mock::expectFilterAdded( 'the_content', \WP_Mock\Functions::type( 'closure' ) );
+
+  add_action( 'save_post', function( $post_id ) { /* ... */ } );
+  add_filter( 'the_content', function( $html ) { /* ... */ } );
+}
+```
+
 #### Asserting that actions and filters are applied
 
 Now that we're testing whether or not we're adding actions and/or filters, the next step is to ensure our code is calling those hooks when expected.

--- a/features/bootstrap/HooksContext.php
+++ b/features/bootstrap/HooksContext.php
@@ -7,261 +7,261 @@ use Behat\Gherkin\Node\TableNode;
 
 class HooksContext implements Context {
 
-	private $filterResults = array();
+  private $filterResults = array();
 
-	/**
-	 * @BeforeScenario
-	 */
-	public function setUpWpMock( BeforeScenarioScope $scope ) {
-		$this->filterResults = array();
-	}
+  /**
+   * @BeforeScenario
+   */
+  public function setUpWpMock( BeforeScenarioScope $scope ) {
+    $this->filterResults = array();
+  }
 
-	/**
-	 * @AfterScenario
-	 */
-	public function tearDownWpMock( AfterScenarioScope $scope ) {
-		$this->filterResults = array();
-	}
+  /**
+   * @AfterScenario
+   */
+  public function tearDownWpMock( AfterScenarioScope $scope ) {
+    $this->filterResults = array();
+  }
 
-	/**
-	 * @Given I expect the following actions added:
-	 */
-	public function iExpectTheFollowingActionsAdded( TableNode $table ) {
-		foreach ( $this->getActionsWithDefaults( $table ) as $action ) {
-			WP_Mock::expectActionAdded(
-				$action['action'],
-				$action['callback'],
-				$action['priority'],
-				$action['arguments']
-			);
-		}
-	}
-
-	/**
-	 * @Given I expect the following actions not to be added:
-	 */
-	public function iExpectTheFollowingActionsNotToBeAdded( TableNode $table ) {
-		foreach ( $this->getActionsWithDefaults( $table ) as $action ) {
-			WP_Mock::expectActionNotAdded( $action['action'], $action['callback'] );
-		}
-	}
-
-	/**
-	 * @Given I expect the :action action
-	 */
-	public function iExpectTheAction( $action ) {
-		$this->iExpectTheActionWith( $action, new TableNode( array() ) );
-	}
-
-	/**
-	 * @When I expect the :action action with:
-	 */
-	public function iExpectTheActionWith( $action, TableNode $table ) {
-		$args = array( $action );
-		$rows = $table->getRows();
-		if ( isset( $rows[0] ) && is_array( $rows[0] ) ) {
-			$args = array_merge( $args, $rows[0] );
-		}
-		call_user_func_array( array( 'WP_Mock', 'expectAction' ), $args );
-	}
-
-	/**
-	 * @Given I expect the :filter filter with :value
-	 */
-	public function iExpectTheFilterWith( $filter, $value ) {
-		$this->iExpectTheFilterWithValues( $filter, new TableNode( array( array( $value ) ) ) );
-	}
-
-	/**
-	 * @When I expect the :filter filter with:
-	 */
-	public function iExpectTheFilterWithValues( $filter, TableNode $table ) {
-		$args = array( $filter );
-		$rows = $table->getRows();
-		if ( isset( $rows[0] ) && is_array( $rows[0] ) ) {
-			$args = array_merge( $args, $rows[0] );
-		}
-		call_user_func_array( array( 'WP_Mock', 'expectFilter' ), $args );
-	}
-
-		/**
-		 * @Given I expect a Closure action to have been added
-		 */
-		public function iExpectAClosureActionToHaveBeenAdded()
-		{
-			WP_Mock::expectActionAdded( 'some_action', \WP_Mock\Functions::type( 'closure' ) );
-		}
-
-		/**
-		 * @When I add a closure action
-		 */
-		public function iAddAClosureAction()
-		{
-			add_action( 'some_action', function() {} );
+  /**
+   * @Given I expect the following actions added:
+   */
+  public function iExpectTheFollowingActionsAdded( TableNode $table ) {
+    foreach ( $this->getActionsWithDefaults( $table ) as $action ) {
+      WP_Mock::expectActionAdded(
+        $action['action'],
+        $action['callback'],
+        $action['priority'],
+        $action['arguments']
+      );
     }
+  }
 
-		/**
-		 * @Given I expect a Closure filter to have been added
-		 */
-		public function iExpectAClosureFilterToHaveBeenAdded()
-		{
-			WP_Mock::expectFilterAdded( 'some_filter', \WP_Mock\Functions::type( 'closure' ) );
-		}
-
-		/**
-		 * @When I add a closure filter
-		 */
-		public function iAddAClosureFilter()
-		{
-			add_filter( 'some_filter', function() {} );
+  /**
+   * @Given I expect the following actions not to be added:
+   */
+  public function iExpectTheFollowingActionsNotToBeAdded( TableNode $table ) {
+    foreach ( $this->getActionsWithDefaults( $table ) as $action ) {
+      WP_Mock::expectActionNotAdded( $action['action'], $action['callback'] );
     }
+  }
 
-	/**
-	 * @When I add the following actions:
-	 */
-	public function iAddTheFollowingActions( TableNode $table ) {
-		foreach ( $this->getActionsWithDefaults( $table ) as $action ) {
-			add_action(
-				$action['action'],
-				$action['callback'],
-				$action['priority'],
-				$action['arguments']
-			);
-		}
-	}
+  /**
+   * @Given I expect the :action action
+   */
+  public function iExpectTheAction( $action ) {
+    $this->iExpectTheActionWith( $action, new TableNode( array() ) );
+  }
 
-	/**
-	 * @When I do the :action action
-	 */
-	public function iDoTheAction( $action ) {
-		$this->iDoTheActionWith( $action, new TableNode( array() ) );
-	}
+  /**
+   * @When I expect the :action action with:
+   */
+  public function iExpectTheActionWith( $action, TableNode $table ) {
+    $args = array( $action );
+    $rows = $table->getRows();
+    if ( isset( $rows[0] ) && is_array( $rows[0] ) ) {
+      $args = array_merge( $args, $rows[0] );
+    }
+    call_user_func_array( array( 'WP_Mock', 'expectAction' ), $args );
+  }
 
-	/**
-	 * @When I do the :action action with:
-	 */
-	public function iDoTheActionWith( $action, TableNode $table ) {
-		$args = array( $action );
-		$rows = $table->getRows();
-		if ( isset( $rows[0] ) && is_array( $rows[0] ) ) {
-			$args = array_merge( $args, $rows[0] );
-		}
-		call_user_func_array( 'do_action', $args );
-	}
+  /**
+   * @Given I expect the :filter filter with :value
+   */
+  public function iExpectTheFilterWith( $filter, $value ) {
+    $this->iExpectTheFilterWithValues( $filter, new TableNode( array( array( $value ) ) ) );
+  }
 
-	/**
-	 * @Given I expect the following filters added:
-	 */
-	public function iExpectTheFollowingFiltersAdded( TableNode $table ) {
-		$filters  = $table->getHash();
-		$defaults = array(
-			'filter'    => '',
-			'callback'  => '',
-			'priority'  => 10,
-			'arguments' => 1,
-		);
-		foreach ( $filters as $filter ) {
-			$filter += $defaults;
-			WP_Mock::expectFilterAdded(
-				$filter['filter'],
-				$filter['callback'],
-				$filter['priority'],
-				$filter['arguments']
-			);
-		}
-	}
+  /**
+   * @When I expect the :filter filter with:
+   */
+  public function iExpectTheFilterWithValues( $filter, TableNode $table ) {
+    $args = array( $filter );
+    $rows = $table->getRows();
+    if ( isset( $rows[0] ) && is_array( $rows[0] ) ) {
+      $args = array_merge( $args, $rows[0] );
+    }
+    call_user_func_array( array( 'WP_Mock', 'expectFilter' ), $args );
+  }
 
-	/**
-	 * @Given I expect the following filters not to be added:
-	 */
-	public function iExpectTheFollowingFiltersNotToBeAdded( TableNode $table ) {
-		foreach ( $this->getFiltersWithDefaults( $table ) as $filter ) {
-			WP_Mock::expectFilterNotAdded( $filter['filter'], $filter['callback'] );
-		}
-	}
+  /**
+   * @Given I expect a Closure action to have been added
+   */
+  public function iExpectAClosureActionToHaveBeenAdded()
+  {
+    WP_Mock::expectActionAdded( 'some_action', \WP_Mock\Functions::type( 'closure' ) );
+  }
 
-	/**
-	 * @When I add the following filters:
-	 */
-	public function iAddTheFollowingFilters( TableNode $table ) {
-		foreach ( $this->getFiltersWithDefaults( $table ) as $filter ) {
-			add_filter(
-				$filter['filter'],
-				$filter['callback'],
-				$filter['priority'],
-				$filter['arguments']
-			);
-		}
-	}
+  /**
+   * @When I add a closure action
+   */
+  public function iAddAClosureAction()
+  {
+    add_action( 'some_action', function() {} );
+  }
 
-	/**
-	 * @Given I expect filter :filter to respond to :thing with :response
-	 */
-	public function iExpectFilterToRespondToWith( $filter, $thing, $response ) {
-		WP_Mock::onFilter( $filter )->with( $thing )->reply( $response );
-	}
+  /**
+   * @Given I expect a Closure filter to have been added
+   */
+  public function iExpectAClosureFilterToHaveBeenAdded()
+  {
+    WP_Mock::expectFilterAdded( 'some_filter', \WP_Mock\Functions::type( 'closure' ) );
+  }
 
-	/**
-	 * @Given I expect filter :filter to respond with :response
-	 */
-	public function iExpectFilterToRespondWith( $filter, $response ) {
-		$this->iExpectFilterToRespondToWith( $filter, null, $response );
-	}
+  /**
+   * @When I add a closure filter
+   */
+  public function iAddAClosureFilter()
+  {
+    add_filter( 'some_filter', function() {} );
+  }
 
-	/**
-	 * @When I apply the filter :filter with :with
-	 */
-	public function iApplyFilterWith( $filter, $with ) {
-		$this->iApplyFilterWithData( $filter, new TableNode( array( array( $with ) ) ) );
-	}
+  /**
+   * @When I add the following actions:
+   */
+  public function iAddTheFollowingActions( TableNode $table ) {
+    foreach ( $this->getActionsWithDefaults( $table ) as $action ) {
+      add_action(
+        $action['action'],
+        $action['callback'],
+        $action['priority'],
+        $action['arguments']
+      );
+    }
+  }
 
-	/**
-	 * @When I apply the filter :filter with:
-	 */
-	public function iApplyFilterWithData( $filter, TableNode $table ) {
-		$row = $table->getRow( 0 );
-		array_unshift( $row, $filter );
-		$this->filterResults[ $filter ] = call_user_func_array( 'apply_filters', $row );
-	}
+  /**
+   * @When I do the :action action
+   */
+  public function iDoTheAction( $action ) {
+    $this->iDoTheActionWith( $action, new TableNode( array() ) );
+  }
 
-	/**
-	 * @Then The filter :filter should return :value
-	 */
-	public function theFilterShouldReturn( $filter, $value ) {
-		\PHPUnit\Framework\Assert::assertArrayHasKey( $filter, $this->filterResults );
-		\PHPUnit\Framework\Assert::assertEquals( $this->filterResults[ $filter ], $value );
-	}
+  /**
+   * @When I do the :action action with:
+   */
+  public function iDoTheActionWith( $action, TableNode $table ) {
+    $args = array( $action );
+    $rows = $table->getRows();
+    if ( isset( $rows[0] ) && is_array( $rows[0] ) ) {
+      $args = array_merge( $args, $rows[0] );
+    }
+    call_user_func_array( 'do_action', $args );
+  }
 
-	private function getActionsWithDefaults( TableNode $table ) {
-		$actions  = $table->getHash();
-		$defaults = array(
-			'action'    => '',
-			'callback'  => '',
-			'priority'  => 10,
-			'arguments' => 1,
-		);
-		foreach ( $actions as &$action ) {
-			$action += $defaults;
-		}
-		unset( $action );
+  /**
+   * @Given I expect the following filters added:
+   */
+  public function iExpectTheFollowingFiltersAdded( TableNode $table ) {
+    $filters  = $table->getHash();
+    $defaults = array(
+      'filter'    => '',
+      'callback'  => '',
+      'priority'  => 10,
+      'arguments' => 1,
+    );
+    foreach ( $filters as $filter ) {
+      $filter += $defaults;
+      WP_Mock::expectFilterAdded(
+        $filter['filter'],
+        $filter['callback'],
+        $filter['priority'],
+        $filter['arguments']
+      );
+    }
+  }
 
-		return $actions;
-	}
+  /**
+   * @Given I expect the following filters not to be added:
+   */
+  public function iExpectTheFollowingFiltersNotToBeAdded( TableNode $table ) {
+    foreach ( $this->getFiltersWithDefaults( $table ) as $filter ) {
+      WP_Mock::expectFilterNotAdded( $filter['filter'], $filter['callback'] );
+    }
+  }
 
-	private function getFiltersWithDefaults( TableNode $table ) {
-		$filters  = $table->getHash();
-		$defaults = array(
-			'filter'    => '',
-			'callback'  => '',
-			'priority'  => 10,
-			'arguments' => 1,
-		);
-		foreach ( $filters as &$filter ) {
-			$filter += $defaults;
-		}
-		unset( $filter );
+  /**
+   * @When I add the following filters:
+   */
+  public function iAddTheFollowingFilters( TableNode $table ) {
+    foreach ( $this->getFiltersWithDefaults( $table ) as $filter ) {
+      add_filter(
+        $filter['filter'],
+        $filter['callback'],
+        $filter['priority'],
+        $filter['arguments']
+      );
+    }
+  }
 
-		return $filters;
-	}
+  /**
+   * @Given I expect filter :filter to respond to :thing with :response
+   */
+  public function iExpectFilterToRespondToWith( $filter, $thing, $response ) {
+    WP_Mock::onFilter( $filter )->with( $thing )->reply( $response );
+  }
+
+  /**
+   * @Given I expect filter :filter to respond with :response
+   */
+  public function iExpectFilterToRespondWith( $filter, $response ) {
+    $this->iExpectFilterToRespondToWith( $filter, null, $response );
+  }
+
+  /**
+   * @When I apply the filter :filter with :with
+   */
+  public function iApplyFilterWith( $filter, $with ) {
+    $this->iApplyFilterWithData( $filter, new TableNode( array( array( $with ) ) ) );
+  }
+
+  /**
+   * @When I apply the filter :filter with:
+   */
+  public function iApplyFilterWithData( $filter, TableNode $table ) {
+    $row = $table->getRow( 0 );
+    array_unshift( $row, $filter );
+    $this->filterResults[ $filter ] = call_user_func_array( 'apply_filters', $row );
+  }
+
+  /**
+   * @Then The filter :filter should return :value
+   */
+  public function theFilterShouldReturn( $filter, $value ) {
+    \PHPUnit\Framework\Assert::assertArrayHasKey( $filter, $this->filterResults );
+    \PHPUnit\Framework\Assert::assertEquals( $this->filterResults[ $filter ], $value );
+  }
+
+  private function getActionsWithDefaults( TableNode $table ) {
+    $actions  = $table->getHash();
+    $defaults = array(
+      'action'    => '',
+      'callback'  => '',
+      'priority'  => 10,
+      'arguments' => 1,
+    );
+    foreach ( $actions as &$action ) {
+      $action += $defaults;
+    }
+    unset( $action );
+
+    return $actions;
+  }
+
+  private function getFiltersWithDefaults( TableNode $table ) {
+    $filters  = $table->getHash();
+    $defaults = array(
+      'filter'    => '',
+      'callback'  => '',
+      'priority'  => 10,
+      'arguments' => 1,
+    );
+    foreach ( $filters as &$filter ) {
+      $filter += $defaults;
+    }
+    unset( $filter );
+
+    return $filters;
+  }
 
 }

--- a/features/bootstrap/HooksContext.php
+++ b/features/bootstrap/HooksContext.php
@@ -84,6 +84,38 @@ class HooksContext implements Context {
 		call_user_func_array( array( 'WP_Mock', 'expectFilter' ), $args );
 	}
 
+		/**
+		 * @Given I expect a Closure action to have been added
+		 */
+		public function iExpectAClosureActionToHaveBeenAdded()
+		{
+			WP_Mock::expectActionAdded( 'some_action', \WP_Mock\Functions::type( 'closure' ) );
+		}
+
+		/**
+		 * @When I add a closure action
+		 */
+		public function iAddAClosureAction()
+		{
+			add_action( 'some_action', function() {} );
+    }
+
+		/**
+		 * @Given I expect a Closure filter to have been added
+		 */
+		public function iExpectAClosureFilterToHaveBeenAdded()
+		{
+			WP_Mock::expectFilterAdded( 'some_filter', \WP_Mock\Functions::type( 'closure' ) );
+		}
+
+		/**
+		 * @When I add a closure filter
+		 */
+		public function iAddAClosureFilter()
+		{
+			add_filter( 'some_filter', function() {} );
+    }
+
 	/**
 	 * @When I add the following actions:
 	 */

--- a/features/hooks.feature
+++ b/features/hooks.feature
@@ -19,6 +19,11 @@ Feature: Hook mocking
     When I do nothing
     Then tearDown should fail
 
+  Scenario: expectActionAdded passes when a closure has been added
+    Given I expect a Closure action to have been added
+		When I add a closure action
+    Then tearDown should not fail
+
   Scenario: expectActionAdded fails when argument count is different
     Given I expect the following actions added:
       | action | callback | priority | arguments |
@@ -68,6 +73,11 @@ Feature: Hook mocking
       | foobar | bazbat   |
     When I do nothing
     Then tearDown should fail
+
+  Scenario: expectFilterAdded passes when a closure has been added
+    Given I expect a Closure filter to have been added
+		When I add a closure filter
+    Then tearDown should not fail
 
   Scenario: expectFilterAdded fails when argument count is different
     Given I expect the following filters added:

--- a/php/WP_Mock/Hook.php
+++ b/php/WP_Mock/Hook.php
@@ -25,6 +25,8 @@ abstract class Hook {
 			return 'null';
 		} elseif ( is_scalar( $value ) ) {
 			return $value;
+		} elseif ( ''.$value === '<Closure>' ) {
+			return '__CLOSURE__';
 		} elseif ( is_object( $value ) ) {
 			return spl_object_hash( $value );
 		} elseif ( is_array( $value ) ) {


### PR DESCRIPTION
This fixes https://github.com/10up/wp_mock/issues/89 and supsedes PRs #130 and https://github.com/10up/wp_mock/pull/119.

The root of the issue turned out to be that using WP_Mock\Functions::type('callable') was causing a mismatch between the safe_offset values returned for the Mockery matcher and the actual closure being passed to add_action. The matcher was getting spl_object_hash'd, while the Closure was getting `"__CLOSURE__"`. Now, safe_offset() treats Mockery matchers with type closure as `"__CLOSURE__"` too.