### PR TITLE
PHP requirement badge should display 7.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Please read [CODE_OF_CONDUCT.md](https://github.com/10up/wp_mock/blob/trunk/CODE
 
 <a href="http://10up.com/contact/"><img src="https://10up.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a>
 
-[php-image]: https://img.shields.io/badge/php-7.1%2B-green.svg
+[php-image]: https://img.shields.io/badge/php-7.3%2B-green.svg
 [packagist-image]: https://img.shields.io/packagist/dt/10up/wp_mock.svg
 [packagist-url]: https://packagist.org/packages/10up/wp_mock
 [coveralls-image]: https://coveralls.io/repos/github/10up/wp_mock/badge.svg?branch=trunk


### PR DESCRIPTION
The badge at the top of the readme file links to an incorrect URL which displays 7.1 instead of the actual 7.3.
