### PR TITLE
Remove WP_Mock TestCase method referencing method removed from PhpUnit

### DIFF
--- a/php/WP_Mock/Tools/TestCase.php
+++ b/php/WP_Mock/Tools/TestCase.php
@@ -14,6 +14,11 @@ use WP_Mock;
 use WP_Mock\Tools\Constraints\ExpectationsMet;
 use WP_Mock\Tools\Constraints\IsEqualHtml;
 
+/**
+ * WP_Mock test case.
+ *
+ * Projects using WP_Mock can extend this class in their unit tests.
+ */
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     /** @var array<string, Mockery\Mock> */
@@ -34,6 +39,13 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     /** @var array<string> */
     protected $testFiles = [];
 
+    /**
+     * Sets up the test case.
+     *
+     * This method is called before each test.
+     *
+     * @return void
+     */
     public function setUp(): void
     {
         $this->requireFileDependencies();
@@ -49,17 +61,22 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $this->cleanGlobals();
     }
 
+    /**
+     * Tears down the test case.
+     *
+     * This method is called after each test.
+     */
     public function tearDown(): void
     {
         WP_Mock::tearDown();
 
         $this->cleanGlobals();
 
-        $this->mockedStaticMethods = array();
+        $this->mockedStaticMethods = [];
 
-        $_GET     = array();
-        $_POST    = array();
-        $_REQUEST = array();
+        $_GET = [];
+        $_POST = [];
+        $_REQUEST = [];
     }
 
     public function assertActionsCalled()

--- a/php/WP_Mock/Tools/TestCase.php
+++ b/php/WP_Mock/Tools/TestCase.php
@@ -10,7 +10,6 @@ use PHPUnit\Util\Test as TestUtil;
 use ReflectionException;
 use ReflectionMethod;
 use RuntimeException;
-use Text_Template;
 use WP_Mock;
 use WP_Mock\Tools\Constraints\ExpectationsMet;
 use WP_Mock\Tools\Constraints\IsEqualHtml;
@@ -144,22 +143,6 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
     {
         $constraint = new IsEqualHtml($expected);
         $this->assertThat($actual, $constraint, $message);
-    }
-
-    /**
-     * Nuke the globals from orbit for process isolation
-     *
-     * See http://kpayne.me/2012/07/02/phpunit-process-isolation-and-constant-already-defined/
-     * for more details
-     *
-     * {@inheritdoc}
-     */
-    protected function prepareTemplate(Text_Template $template)
-    {
-        $template->setVar(array(
-            'globals' => '$GLOBALS[\'__PHPUNIT_BOOTSTRAP\'] = \'' . $GLOBALS['__PHPUNIT_BOOTSTRAP'] . '\';',
-        ));
-        parent::prepareTemplate($template);
     }
 
 

--- a/php/WP_Mock/Tools/TestCase.php
+++ b/php/WP_Mock/Tools/TestCase.php
@@ -16,32 +16,23 @@ use WP_Mock\Tools\Constraints\IsEqualHtml;
 
 abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
-    protected $mockedStaticMethods = array();
+    /** @var array<string, Mockery\Mock> */
+    protected $mockedStaticMethods = [];
 
-    /**
-     * @var array
-     */
-    protected $__default_post = array();
+    /** @var array<mixed> */
+    protected $__default_post = [];
 
-    /**
-     * @var array
-     */
-    protected $__default_get = array();
+    /** @var array<mixed> */
+    protected $__default_get = [];
 
-    /**
-     * @var array
-     */
-    protected $__default_request = array();
+    /** @var array<mixed> */
+    protected $__default_request = [];
 
-    /**
-     * @var bool|callable
-     */
+    /** @var bool|callable */
     protected $__contentFilterCallback = false;
 
-    /**
-     * @var array
-     */
-    protected $testFiles = array();
+    /** @var array<string> */
+    protected $testFiles = [];
 
     public function setUp(): void
     {


### PR DESCRIPTION
# Summary <!-- Required -->

Removes `Text_Template` and `prepareTemplate` references and methods from WP_Mock.

### Closes: https://github.com/10up/wp_mock/issues/187

## Contributor checklist <!-- Required -->

- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly 
- [ ] I have added tests to cover changes introduced by this pull request
- [ ] All new and existing tests pass

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes