### PR TITLE
IsEqualHtml should extend PhpUnit Constraint

### DIFF
--- a/php/WP_Mock/Tools/Constraints/ExpectationsMet.php
+++ b/php/WP_Mock/Tools/Constraints/ExpectationsMet.php
@@ -6,18 +6,32 @@ use PHPUnit\Framework\Constraint\Constraint;
 use Mockery;
 use Exception;
 
-class ExpectationsMet extends \PHPUnit\Framework\Constraint\Constraint
+/**
+ * Expectations-met constraint.
+ */
+class ExpectationsMet extends Constraint
 {
-    private $_mockery_message;
+    /** @var string */
+    private $failureDescription;
 
+    /**
+     * Evaluates the constraint for parameter $other.
+     *
+     * Returns true if the constraint is met, false otherwise.
+     *
+     * @param mixed $other
+     * @return bool
+     */
     public function matches($other): bool
     {
         try {
             Mockery::getContainer()->mockery_verify();
-        } catch (Exception $e) {
-            $this->_mockery_message = $e->getMessage();
+        } catch (Exception $exception) {
+            $this->failureDescription = $exception->getMessage();
+
             return false;
         }
+
         return true;
     }
 
@@ -28,14 +42,26 @@ class ExpectationsMet extends \PHPUnit\Framework\Constraint\Constraint
      */
     public function toString(): string
     {
-        return 'WP Mock expectations are met';
+        return 'WP_Mock expectations are met';
     }
 
+    /**
+     * Gets the additional failure description.
+     *
+     * @param mixed $other
+     * @return string
+     */
     protected function additionalFailureDescription($other): string
     {
-        return str_replace(array( "\r", "\n" ), '', (string) $this->_mockery_message);
+        return str_replace(["\r", "\n"], '', $this->failureDescription);
     }
 
+    /**
+     * Gets the failure description.
+     *
+     * @param mixed $other
+     * @return string
+     */
     protected function failureDescription($other): string
     {
         return $this->toString();

--- a/php/WP_Mock/Tools/Constraints/IsEqualHtml.php
+++ b/php/WP_Mock/Tools/Constraints/IsEqualHtml.php
@@ -2,59 +2,92 @@
 
 namespace WP_Mock\Tools\Constraints;
 
+use Exception;
+use PHPUnit\Framework\Constraint\Constraint;
 use PHPUnit\Framework\Constraint\IsEqual;
+use PHPUnit\Framework\ExpectationFailedException;
 
-class IsEqualHtml
+/**
+ * HTML string constraint.
+ */
+class IsEqualHtml extends Constraint
 {
-    protected $IsEqual;
+    /** @var string */
     protected $value;
 
-    /**
-     * @var float
-     */
+    /** @var float */
     private $delta;
 
-    /**
-     * @var int
-     */
-    private $maxDepth;
-
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $canonicalize;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $ignoreCase;
 
-    public function __construct(
-        $value,
-        float $delta = 0.0,
-        int $maxDepth = 10,
-        bool $canonicalize = false,
-        bool $ignoreCase = false
-    ) {
+    /**
+     * Constructor.
+     *
+     * @param string $value
+     * @param float $delta
+     * @param bool $canonicalize
+     * @param bool $ignoreCase
+     */
+    public function __construct(string $value, float $delta = 0.0, bool $canonicalize = false, bool $ignoreCase = false)
+    {
         $this->value = $value;
         $this->delta = $delta;
-        $this->maxDepth = $maxDepth;
         $this->canonicalize = $canonicalize;
         $this->ignoreCase = $ignoreCase;
     }
 
-    private function clean($thing)
+    /**
+     * Trims and removes tabs, newlines and return carriages from a string.
+     *
+     * @param string $value
+     * @return string
+     */
+    private function clean(string $value): string
     {
-        $thing = preg_replace('/\n\s+/', '', $thing);
-        $thing = preg_replace('/\s\s+/', ' ', $thing);
-        return str_replace(array( "\r", "\n", "\t" ), '', $thing);
+        $value = preg_replace('/\n\s+/', '', $value) ?: '';
+        $value = preg_replace('/\s\s+/', ' ', $value) ?: '';
+
+        return str_replace(array( "\r", "\n", "\t" ), '', $value);
     }
 
-    public function evaluate($other, $description = '', $returnResult = false)
+    /**
+     * Evaluates the constraint for parameter $other.
+     *
+     * If $returnResult is false (default), an exception is thrown in case of a failure. null is returned otherwise.
+     * If $returnResult is true, the result of the evaluation is returned as a boolean instead, based on success or failure.
+     *
+     * @param string $other value to evaluate
+     * @param string $description message used in failures
+     * @param bool $returnResult whether to throw an exception in case of failure or return boolean
+     * @return bool|null
+     * @throws ExpectationFailedException
+     */
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
-        $other       = $this->clean($other);
+        $other = $this->clean($other);
         $this->value = $this->clean($this->value);
-        $isEqual = new IsEqual($this->value, $this->delta, $this->maxDepth, $this->canonicalize, $this->ignoreCase);
+
+        $isEqual = new IsEqual($this->value, $this->delta, $this->canonicalize, $this->ignoreCase);
+
         return $isEqual->evaluate($other, $description, $returnResult);
+    }
+
+    /**
+     * Returns a string representation of the constraint.
+     *
+     * @see Constraint::toString()
+     *
+     * @return string
+     * @throws Exception
+     */
+    public function toString(): string
+    {
+        $isEqual = new IsEqual($this->value, $this->delta, $this->canonicalize, $this->ignoreCase);
+
+        return 'html '.$isEqual->toString();
     }
 }

--- a/php/WP_Mock/Tools/Constraints/IsEqualHtml.php
+++ b/php/WP_Mock/Tools/Constraints/IsEqualHtml.php
@@ -16,13 +16,13 @@ class IsEqualHtml extends Constraint
     protected $value;
 
     /** @var float */
-    private $delta;
+    protected $delta;
 
     /** @var bool */
-    private $canonicalize;
+    protected $canonicalize;
 
     /** @var bool */
-    private $ignoreCase;
+    protected $ignoreCase;
 
     /**
      * Constructor.

--- a/php/WP_Mock/Tools/Constraints/IsEqualHtml.php
+++ b/php/WP_Mock/Tools/Constraints/IsEqualHtml.php
@@ -16,13 +16,13 @@ class IsEqualHtml extends Constraint
     protected $value;
 
     /** @var float */
-    protected $delta;
+    private $delta;
 
     /** @var bool */
-    protected $canonicalize;
+    private $canonicalize;
 
     /** @var bool */
-    protected $ignoreCase;
+    private $ignoreCase;
 
     /**
      * Constructor.

--- a/php/WP_Mock/Tools/Constraints/IsEqualHtml.php
+++ b/php/WP_Mock/Tools/Constraints/IsEqualHtml.php
@@ -46,7 +46,7 @@ class IsEqualHtml extends Constraint
      * @param string $value
      * @return string
      */
-    private function clean(string $value): string
+    protected function clean(string $value): string
     {
         $value = preg_replace('/\n\s+/', '', $value) ?: '';
         $value = preg_replace('/\s\s+/', ' ', $value) ?: '';
@@ -72,8 +72,9 @@ class IsEqualHtml extends Constraint
         $this->value = $this->clean($this->value);
 
         $isEqual = new IsEqual($this->value, $this->delta, $this->canonicalize, $this->ignoreCase);
+        $result = $isEqual->evaluate($other, $description, $returnResult);
 
-        return $isEqual->evaluate($other, $description, $returnResult);
+        return $returnResult ? $result : null;
     }
 
     /**

--- a/php/WP_Mock/Tools/TestCase.php
+++ b/php/WP_Mock/Tools/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace WP_Mock\Tools;
 
+use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestResult;
 use Exception;
 use InvalidArgumentException;
@@ -147,12 +148,21 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         $this->assertCurrentConditionsMet($message);
     }
 
-    public function assertEqualsHTML($expected, $actual, $message = '')
+    /**
+     * Evaluates that an HTML string is equal to another.
+     *
+     * @param string $expected
+     * @param string $actual
+     * @param string $message
+     * @return void
+     * @throws ExpectationFailedException|Exception
+     */
+    public function assertEqualsHTML(string $expected, string $actual, string $message = ''): void
     {
         $constraint = new IsEqualHtml($expected);
+
         $this->assertThat($actual, $constraint, $message);
     }
-
 
     /**
      * Mocks a static method of a class.

--- a/php/WP_Mock/Tools/TestCase.php
+++ b/php/WP_Mock/Tools/TestCase.php
@@ -157,7 +157,7 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
      * @return void
      * @throws ExpectationFailedException|Exception
      */
-    public function assertEqualsHTML(string $expected, string $actual, string $message = ''): void
+    public function assertEqualsHtml(string $expected, string $actual, string $message = ''): void
     {
         $constraint = new IsEqualHtml($expected);
 

--- a/php/WP_Mock/Tools/TestCase.php
+++ b/php/WP_Mock/Tools/TestCase.php
@@ -138,14 +138,29 @@ abstract class TestCase extends \PHPUnit\Framework\TestCase
         parent::expectOutputString($expectedString);
     }
 
-    public function assertCurrentConditionsMet($message = '')
+    /**
+     * Asserts that the current test conditions have been met.
+     *
+     * @deprecated prefer {@see TestCase::assertConditionsMet())
+     *
+     * @param string $message
+     * @return void
+     */
+    public function assertCurrentConditionsMet(string $message = ''): void
     {
-        $this->assertThat(null, new ExpectationsMet(), $message);
+        $this->assertConditionsMet($message);
     }
 
-    public function assertConditionsMet($message = '')
+    /**
+     * Asserts that the current test conditions have been met.
+     *
+     * @param string $message
+     * @return void
+     */
+    public function assertConditionsMet(string $message = ''): void
     {
-        $this->assertCurrentConditionsMet($message);
+        /** @phpstan-ignore-next-line it will never throw an exception */
+        $this->assertThat(null, new ExpectationsMet(), $message);
     }
 
     /**

--- a/tests/Unit/WP_Mock/Tools/Constraints/ExpectationsMetTest.php
+++ b/tests/Unit/WP_Mock/Tools/Constraints/ExpectationsMetTest.php
@@ -2,6 +2,10 @@
 
 namespace WP_Mock\Tests\Unit\WP_Mock\Tools\Constraints;
 
+use Exception;
+use ReflectionException;
+use ReflectionMethod;
+use ReflectionProperty;
 use WP_Mock\Tests\WP_MockTestCase;
 use WP_Mock\Tools\Constraints\ExpectationsMet;
 
@@ -14,9 +18,41 @@ final class ExpectationsMetTest extends WP_MockTestCase
      * @covers \WP_Mock\Tools\Constraints\ExpectationsMet::toString()
      *
      * @return void
+     * @throws Exception
      */
-    public function testCanConvertToString() : void
+    public function testCanConvertToString(): void
     {
         $this->assertSame('WP_Mock expectations are met', (new ExpectationsMet())->toString());
+    }
+
+    /**
+     * @covers \WP_Mock\Tools\Constraints\ExpectationsMet::failureDescription()
+     *
+     * @return void
+     * @throws ReflectionException|Exception
+     */
+    public function testCanGetFailureDescription(): void
+    {
+        $constraint = new ExpectationsMet();
+        $method = new ReflectionMethod($constraint, 'failureDescription');
+
+        $this->assertSame('WP_Mock expectations are met', $method->invokeArgs($constraint, [null]));
+    }
+
+    /**
+     * @covers \WP_Mock\Tools\Constraints\ExpectationsMet::additionalFailureDescription()
+     *
+     * @return void
+     * @throws ReflectionException|Exception
+     */
+    public function testCanGetAdditionalFailureDescription(): void
+    {
+        $constraint = new ExpectationsMet();
+        $method = new ReflectionMethod($constraint, 'additionalFailureDescription');
+        $property = new ReflectionProperty($constraint, 'failureDescription');
+
+        $property->setValue($constraint, "\n\nTest\r");
+
+        $this->assertSame('Test', $method->invokeArgs($constraint, [null]));
     }
 }

--- a/tests/Unit/WP_Mock/Tools/Constraints/ExpectationsMetTest.php
+++ b/tests/Unit/WP_Mock/Tools/Constraints/ExpectationsMetTest.php
@@ -15,6 +15,19 @@ use WP_Mock\Tools\Constraints\ExpectationsMet;
 final class ExpectationsMetTest extends WP_MockTestCase
 {
     /**
+     * @covers \WP_Mock\Tools\Constraints\ExpectationsMet::matches()
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testMatches(): void
+    {
+        $constraint = new ExpectationsMet();
+
+        $this->assertTrue($constraint->matches(null));
+    }
+
+    /**
      * @covers \WP_Mock\Tools\Constraints\ExpectationsMet::toString()
      *
      * @return void

--- a/tests/Unit/WP_Mock/Tools/Constraints/ExpectationsMetTest.php
+++ b/tests/Unit/WP_Mock/Tools/Constraints/ExpectationsMetTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace WP_Mock\Tests\Unit\WP_Mock\Tools\Constraints;
+
+use WP_Mock\Tests\WP_MockTestCase;
+use WP_Mock\Tools\Constraints\ExpectationsMet;
+
+/**
+ * @covers \WP_Mock\Tools\Constraints\ExpectationsMet
+ */
+final class ExpectationsMetTest extends WP_MockTestCase
+{
+    /**
+     * @covers \WP_Mock\Tools\Constraints\ExpectationsMet::toString()
+     *
+     * @return void
+     */
+    public function testCanConvertToString() : void
+    {
+        $this->assertSame('WP_Mock expectations are met', (new ExpectationsMet())->toString());
+    }
+}

--- a/tests/Unit/WP_Mock/Tools/Constraints/ExpectationsMetTest.php
+++ b/tests/Unit/WP_Mock/Tools/Constraints/ExpectationsMetTest.php
@@ -48,6 +48,7 @@ final class ExpectationsMetTest extends WP_MockTestCase
     {
         $constraint = new ExpectationsMet();
         $method = new ReflectionMethod($constraint, 'failureDescription');
+        $method->setAccessible(true);
 
         $this->assertSame('WP_Mock expectations are met', $method->invokeArgs($constraint, [null]));
     }
@@ -62,7 +63,9 @@ final class ExpectationsMetTest extends WP_MockTestCase
     {
         $constraint = new ExpectationsMet();
         $method = new ReflectionMethod($constraint, 'additionalFailureDescription');
+        $method->setAccessible(true);
         $property = new ReflectionProperty($constraint, 'failureDescription');
+        $property->setAccessible(true);
 
         $property->setValue($constraint, "\n\nTest\r");
 

--- a/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
+++ b/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
@@ -35,6 +35,7 @@ final class IsEqualHtmlTest extends WP_MockTestCase
 
         foreach ($props as $key => $value) {
             $property = new ReflectionProperty($constraint, $key);
+            $property->setAccessible(true);
 
             $this->assertSame($value, $property->getValue($constraint));
         }
@@ -51,6 +52,7 @@ final class IsEqualHtmlTest extends WP_MockTestCase
         $value = "\n\t <p>Test </p>\r";
         $constraint = new IsEqualHtml($value);
         $method = new ReflectionMethod($constraint, 'clean');
+        $method->setAccessible(true);
 
         $this->assertSame('<p>Test </p>', $method->invokeArgs($constraint, [$value]));
     }

--- a/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
+++ b/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
@@ -74,4 +74,17 @@ final class IsEqualHtmlTest extends WP_MockTestCase
             'throwsException' => true,
         ];
     }
+
+    /**
+     * @covers \WP_Mock\Tools\Constraints\IsEqualHtml::toString()
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testCanConvertToString() : void
+    {
+        $constraint = new IsEqualHtml('<body>Test</body>');
+
+        $this->assertSame('html is equal to \'<body>Test</body>\'', $constraint->toString());
+    }
 }

--- a/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
+++ b/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace WP_Mock\Tests\Unit\WP_Mock\Tools\Constraints;
+
+use Exception;
+use Generator;
+use PHPUnit\Framework\ExpectationFailedException;
+use WP_Mock\Tests\WP_MockTestCase;
+use WP_Mock\Tools\Constraints\IsEqualHtml;
+
+/**
+ * @covers \WP_Mock\Tools\Constraints\IsEqualHtml
+ */
+final class IsEqualHtmlTest extends WP_MockTestCase
+{
+    /**
+     * @covers \WP_Mock\Tools\Constraints\IsEqualHtml::evaluate()
+     * @dataProvider providerEvaluate
+     *
+     * @param string $value
+     * @param string $otherValue
+     * @param bool $returnResult
+     * @param bool|null $expected
+     * @param bool|null $throwsException
+     * @return void
+     * @throws Exception
+     */
+    public function testCanEvaluate(
+        string $value,
+        string $otherValue,
+        bool $returnResult,
+        ?bool $expected,
+        ?bool $throwsException = null
+    ) : void {
+        $constraint = new IsEqualHtml($value);
+
+        if ($throwsException) {
+            $this->expectException(ExpectationFailedException::class);
+        }
+
+        $this->assertSame($expected, $constraint->evaluate($otherValue, 'Test error message', $returnResult));
+    }
+
+    /** @see testCanEvaluate */
+    public function providerEvaluate() : Generator
+    {
+        yield 'The two HTML strings are the same (return bool)' => [
+            'value' => '<strong>Test</strong>',
+            'otherValue' => '<strong>Test</strong>',
+            'returnResult' => true,
+            'expected' => true,
+        ];
+
+        yield 'The two HTML strings are the same (throw exception)' => [
+            'value' => '<strong>Test</strong>',
+            'otherValue' => '<strong>Test</strong>',
+            'returnResult' => false,
+            'expected' => null,
+            'throwsException' => false,
+        ];
+
+        yield 'The two HTML strings are not the same (return bool)' => [
+            'value' => '<strong>Test</strong>',
+            'otherValue' => '<em>Test</em>',
+            'returnResult' => true,
+            'expected' => false,
+        ];
+
+        yield 'The two HTML strings are not the same (throw exception)' => [
+            'value' => '<strong>Test</strong>',
+            'otherValue' => '<em>Test</em>',
+            'returnResult' => false,
+            'expected' => null,
+            'throwsException' => true,
+        ];
+    }
+}

--- a/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
+++ b/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
@@ -5,6 +5,8 @@ namespace WP_Mock\Tests\Unit\WP_Mock\Tools\Constraints;
 use Exception;
 use Generator;
 use PHPUnit\Framework\ExpectationFailedException;
+use ReflectionException;
+use ReflectionMethod;
 use WP_Mock\Tests\WP_MockTestCase;
 use WP_Mock\Tools\Constraints\IsEqualHtml;
 
@@ -13,6 +15,21 @@ use WP_Mock\Tools\Constraints\IsEqualHtml;
  */
 final class IsEqualHtmlTest extends WP_MockTestCase
 {
+    /**
+     * @covers \WP_Mock\Tools\Constraints\IsEqualHtml::clean()
+     *
+     * @return void
+     * @throws ReflectionException|Exception
+     */
+    public function testCanClean(): void
+    {
+        $value = "\n\t <p>Test </p>\r";
+        $constraint = new IsEqualHtml($value);
+        $method = new ReflectionMethod($constraint, 'clean');
+
+        $this->assertSame('<p>Test </p>', $method->invokeArgs($constraint, [$value]));
+    }
+
     /**
      * @covers \WP_Mock\Tools\Constraints\IsEqualHtml::evaluate()
      * @dataProvider providerEvaluate

--- a/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
+++ b/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
@@ -31,7 +31,7 @@ final class IsEqualHtmlTest extends WP_MockTestCase
         bool $returnResult,
         ?bool $expected,
         ?bool $throwsException = null
-    ) : void {
+    ): void {
         $constraint = new IsEqualHtml($value);
 
         if ($throwsException) {
@@ -42,7 +42,7 @@ final class IsEqualHtmlTest extends WP_MockTestCase
     }
 
     /** @see testCanEvaluate */
-    public function providerEvaluate() : Generator
+    public function providerEvaluate(): Generator
     {
         yield 'The two HTML strings are the same (return bool)' => [
             'value' => '<strong>Test</strong>',
@@ -81,7 +81,7 @@ final class IsEqualHtmlTest extends WP_MockTestCase
      * @return void
      * @throws Exception
      */
-    public function testCanConvertToString() : void
+    public function testCanConvertToString(): void
     {
         $constraint = new IsEqualHtml('<body>Test</body>');
 

--- a/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
+++ b/tests/Unit/WP_Mock/Tools/Constraints/IsEqualHtmlTest.php
@@ -7,6 +7,7 @@ use Generator;
 use PHPUnit\Framework\ExpectationFailedException;
 use ReflectionException;
 use ReflectionMethod;
+use ReflectionProperty;
 use WP_Mock\Tests\WP_MockTestCase;
 use WP_Mock\Tools\Constraints\IsEqualHtml;
 
@@ -15,6 +16,30 @@ use WP_Mock\Tools\Constraints\IsEqualHtml;
  */
 final class IsEqualHtmlTest extends WP_MockTestCase
 {
+    /**
+     * @covers \WP_Mock\Tools\Constraints\IsEqualHtml::__construct()
+     *
+     * @return void
+     * @throws ReflectionException|Exception
+     */
+    public function testConstructor(): void
+    {
+        $props = [
+            'value' => 'Test',
+            'delta' => 1.2,
+            'canonicalize' => true,
+            'ignoreCase' => true,
+        ];
+
+        $constraint = new IsEqualHtml($props['value'], $props['delta'], $props['canonicalize'], $props['ignoreCase']);
+
+        foreach ($props as $key => $value) {
+            $property = new ReflectionProperty($constraint, $key);
+
+            $this->assertSame($value, $property->getValue($constraint));
+        }
+    }
+
     /**
      * @covers \WP_Mock\Tools\Constraints\IsEqualHtml::clean()
      *


### PR DESCRIPTION
<!--
Filling out the required portions of this template is mandatory. 
Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.
All new code requires associated documentation and unit tests.
-->

# Summary <!-- Required -->

Supersedes  https://github.com/10up/wp_mock/pull/146 with unit tests, and resolving merge conflicts. 

### Closes: #144

## Details

I have also added test coverage for `ExpectationsMet` constraint.

## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing <!-- Required -->

<!-- If applicable, add specific steps for the reviewer to perform as part of their testing process prior to approving this pull request. -->

<!-- List any configuration requirements for testing. -->

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [x] Code changes review
- [ ] Documentation changes review
- [x] Unit tests pass
- [x] Static analysis passes