### PR TITLE
Fix doc links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ composer require --dev 10up/wp_mock
 
 ## Documentation
 
-Learn more about how to configure and how to use WP_Mock by reading [the WP_Mock documentation](https://wp-mock.gitbook.io/documentation/general/introduction).
+Learn more about how to configure and how to use WP_Mock by reading [the WP_Mock documentation](https://wp-mock.gitbook.io/documentation/getting-started/introduction).
 
 ## Contributing
 
@@ -22,7 +22,7 @@ Please read our [Code of Conduct](https://github.com/10up/wp_mock/blob/trunk/COD
 
 ## Supporters
 
-WP_Mock is supported by [10up](https://10up.com) and [GoDaddy](https://godaddy.com). [GitBook](https://www.gitbook.com/) kindly offers free hosting for [WP_Mock documentation](https://wp-mock.gitbook.io/documentation/general/introduction).
+WP_Mock is supported by [10up](https://10up.com) and [GoDaddy](https://godaddy.com). [GitBook](https://www.gitbook.com/) kindly offers free hosting for [WP_Mock documentation](https://wp-mock.gitbook.io/documentation/getting-started/introduction).
 
 A special thanks to all [WP_Mock contributors](https://github.com/10up/wp_mock/graphs/contributors).
 


### PR DESCRIPTION
# Summary <!-- Required -->

Documentation links to the wrong page in the README.md - this PR fixes that.

## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing <!-- Required -->

No code changes - just verify links in README.md work correctly - they should point to the docs Introduction page.

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes