### PR TITLE
Update Mockery to 1.6 (require PHP 7.4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,6 @@ jobs:
             os: 'ubuntu-20.04'
           - php: '7.4'
             os: 'ubuntu-20.04'
-          # the deprecated Ubuntu 18.04 image has been removed from GitHub workflows
-          # @TODO we need to switch to setup-php action to install PHP 7.3 on a supported image
-          # - php: '7.3'
-          #  os: 'ubuntu-18.04' # PHP 7.3 is not pre-installed in ubuntu-latest
       fail-fast: false
     env:
       COVERAGE_CACHE_PATH: phpunit-coverage-cache

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > WP_Mock is an API mocking framework, built and maintained by [10up](https://10up.com) and [GoDaddy](https://godaddy.com) for the purpose of making it possible to properly unit test within a WordPress project.
 
-[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) ![PHP 7.3+][php-image] [![Coverage Status][coveralls-image]][coveralls-url] [![Packagist][packagist-image]][packagist-url] [![GPLv2 License](https://img.shields.io/badge/license-GPL--2.0-orange)](https://github.com/10up/wp_mock/blob/trunk/LICENSE.md)
+[![Support Level](https://img.shields.io/badge/support-active-green.svg)](#support-level) ![PHP 7.4+][php-image] [![Coverage Status][coveralls-image]][coveralls-url] [![Packagist][packagist-image]][packagist-url] [![GPLv2 License](https://img.shields.io/badge/license-GPL--2.0-orange)](https://github.com/10up/wp_mock/blob/trunk/LICENSE.md)
 
 ## Installation
 
@@ -30,7 +30,7 @@ A special thanks to all [WP_Mock contributors](https://github.com/10up/wp_mock/g
 
 <a href="http://10up.com/contact/"><img src="https://10up.com/uploads/2016/10/10up-Github-Banner.png" width="850"></a>
 
-[php-image]: https://img.shields.io/badge/php-7.3%2B-green.svg
+[php-image]: https://img.shields.io/badge/php-7.4%2B-green.svg
 [packagist-image]: https://img.shields.io/packagist/dt/10up/wp_mock.svg
 [packagist-url]: https://packagist.org/packages/10up/wp_mock
 [coveralls-image]: https://coveralls.io/repos/github/10up/wp_mock/badge.svg?branch=trunk

--- a/composer.json
+++ b/composer.json
@@ -5,9 +5,9 @@
     "version": "0.5.0",
     "prefer-stable": true,
     "require": {
-        "php": ">=7.3 < 9.0",
+        "php": ">=7.4 < 8.3",
         "phpunit/phpunit": "^9.5.24",
-        "mockery/mockery": "^1.5",
+        "mockery/mockery": "^1.6",
         "antecedent/patchwork": "^2.1"
     },
     "require-dev": {
@@ -42,7 +42,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.3"
+            "php": "7.4"
         },
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b673bdd07331f32526670dd358959634",
+    "content-hash": "355a554fe95136682e5e61f867845926",
     "packages": [
         {
             "name": "antecedent/patchwork",
@@ -177,38 +177,44 @@
         },
         {
             "name": "mockery/mockery",
-            "version": "1.5.1",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mockery/mockery.git",
-                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e"
+                "reference": "13a7fa2642c76c58fa2806ef7f565344c817a191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mockery/mockery/zipball/e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
-                "reference": "e92dcc83d5a51851baf5f5591d32cb2b16e3684e",
+                "url": "https://api.github.com/repos/mockery/mockery/zipball/13a7fa2642c76c58fa2806ef7f565344c817a191",
+                "reference": "13a7fa2642c76c58fa2806ef7f565344c817a191",
                 "shasum": ""
             },
             "require": {
                 "hamcrest/hamcrest-php": "^2.0.1",
                 "lib-pcre": ">=7.0",
-                "php": "^7.3 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "conflict": {
                 "phpunit/phpunit": "<8.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^8.5 || ^9.3"
+                "phpunit/phpunit": "^8.5 || ^9.3",
+                "psalm/plugin-phpunit": "^0.18",
+                "vimeo/psalm": "^5.9"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-main": "1.6.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Mockery": "library/"
+                "files": [
+                    "library/helpers.php",
+                    "library/Mockery.php"
+                ],
+                "psr-4": {
+                    "Mockery\\": "library/Mockery"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -243,9 +249,9 @@
             ],
             "support": {
                 "issues": "https://github.com/mockery/mockery/issues",
-                "source": "https://github.com/mockery/mockery/tree/1.5.1"
+                "source": "https://github.com/mockery/mockery/tree/1.6.2"
             },
-            "time": "2022-09-07T15:32:08+00:00"
+            "time": "2023-06-07T09:07:52+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -5772,11 +5778,11 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3 < 9.0"
+        "php": ">=7.4 < 8.3"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.3"
+        "php": "7.4"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/docs/general/installation.md
+++ b/docs/general/installation.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-* PHP 7.3+
+* PHP 7.4+
 * Composer 2.0+
 
 ## Install WP_Mock
@@ -18,7 +18,7 @@ composer require --dev 10up/wp_mock
 WP_Mock needs the following dependencies to work:
 
 * PHPUnit ^9.5 (BSD 3-Clause license)
-* Mockery ^1.5 (BSD 3-Clause license)
+* Mockery ^1.6 (BSD 3-Clause license)
 * Patchwork ^2.1 (MIT license)
 
 They will be installed for you by Composer.

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,5 +4,5 @@
 	<file>./tests</file>
 	<arg value="sp"/>
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="7.3"/>
+	<config name="testVersion" value="7.4"/>
 </ruleset>


### PR DESCRIPTION
# Summary <!-- Required -->

Bumps [Mockery](https://github.com/mockery/mockery) to [1.6](https://github.com/mockery/mockery/releases/tag/1.6.2) to address #204 (among other bugs as per Mockery [changelog](https://github.com/mockery/mockery/releases)) - this would also require using PHP 7.4 though, which would render #212 moot.

May be worth considering tagging v1.0.0 after this change is validated given the PHP bump.

#### 🏁 Closes #204
#### 🏁 Closes #212

## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing <!-- Required -->

- [x] Code review
- [x] Unit tests pass

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes