### PR TITLE
Add invokeInaccessibleMethod and getInaccessiblePropertyValue trait methods

### DIFF
--- a/php/WP_Mock/Traits/AccessInaccessibleClassMembersTrait.php
+++ b/php/WP_Mock/Traits/AccessInaccessibleClassMembersTrait.php
@@ -67,7 +67,7 @@ trait AccessInaccessibleClassMembersTrait
     }
 
     /**
-     * Gets the given inaccessible property for the given class.
+     * Gets the given inaccessible property value for the given class.
      *
      * Allows for calling protected and private properties on a class.
      *

--- a/php/WP_Mock/Traits/AccessInaccessibleClassMembersTrait.php
+++ b/php/WP_Mock/Traits/AccessInaccessibleClassMembersTrait.php
@@ -33,6 +33,20 @@ trait AccessInaccessibleClassMembersTrait
     }
 
     /**
+     * Invokes the given inaccessible method on the given class.
+     *
+     * @param object $class the class name or instance to call against
+     * @param string $methodName the method name to call
+     * @param mixed ...$args arguments to pass to the invoked method
+     * @return mixed
+     * @throws ReflectionException
+     */
+    public function invokeInaccessibleMethod(object $class, string $methodName, ...$args)
+    {
+        return $this->getInaccessibleMethod($class, $methodName)->invoke($class, ...$args);
+    }
+
+    /**
      * Gets the given inaccessible property for the given class.
      *
      * Allows for calling protected and private properties on a class.
@@ -50,6 +64,21 @@ trait AccessInaccessibleClassMembersTrait
         $property->setAccessible(true);
 
         return $property;
+    }
+
+    /**
+     * Gets the given inaccessible property for the given class.
+     *
+     * Allows for calling protected and private properties on a class.
+     *
+     * @param object $class the class name or instance
+     * @param string $property the property name
+     * @return mixed the property value
+     * @throws ReflectionException
+     */
+    public function getInaccessiblePropertyValue(object $class, string $property)
+    {
+        return $this->getInaccessibleProperty($class, $property)->getValue($class);
     }
 
     /**

--- a/tests/Unit/WP_Mock/Traits/AccessInaccessibleClassMembersTraitTest.php
+++ b/tests/Unit/WP_Mock/Traits/AccessInaccessibleClassMembersTraitTest.php
@@ -21,7 +21,6 @@ final class AccessInaccessibleClassMembersTraitTest extends TestCase
     public function testCanGetInaccessibleProperty(): void
     {
         $instance = $this->getInstance('test');
-        /* @phpstan-ignore-next-line */
         $property = $instance->getInaccessibleProperty($instance, 'property');
 
         $this->assertEquals('property', $property->getName());
@@ -43,10 +42,23 @@ final class AccessInaccessibleClassMembersTraitTest extends TestCase
     }
 
     /**
+     * @covers \WP_Mock\Traits\AccessInaccessibleClassMembersTrait::getInaccessiblePropertyValue()
+     *
+     * @return void
+     * @throws ReflectionException|Exception
+     */
+    public function testCanGetInaccessiblePropertyValue(): void
+    {
+        $instance = $this->getInstance('test');
+
+        $this->assertEquals('test', $instance->getInaccessiblePropertyValue($instance, 'property'));
+    }
+
+    /**
      * @covers \WP_Mock\Traits\AccessInaccessibleClassMembersTrait::getInaccessibleMethod()
      *
      * @return void
-     * @throws Exception
+     * @throws ReflectionException|Exception
      */
     public function testCanGetInaccessibleMethod(): void
     {
@@ -55,6 +67,19 @@ final class AccessInaccessibleClassMembersTraitTest extends TestCase
 
         $this->assertEquals('method', $method->getName());
         $this->assertEquals('test', $method->invoke($instance));
+    }
+
+    /**
+     * @covers \WP_Mock\Traits\AccessInaccessibleClassMembersTrait::invokeInaccessibleMethod()
+     *
+     * @return void
+     * @throws ReflectionException|Exception
+     */
+    public function testCanInvokeInaccessibleMethod(): void
+    {
+        $instance = $this->getInstance('test');
+
+        $this->assertEquals('test', $instance->invokeInaccessibleMethod($instance, 'method'));
     }
 
     /**


### PR DESCRIPTION
<!--
Filling out the required portions of this template is mandatory. 
Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.
All new code requires associated documentation and unit tests.
-->

# Summary <!-- Required -->

Improves the `AccessInaccessibleClassMembersTrait` used in `WP_Mock` own `TestCase` to invoke an inaccessible class method or get an inaccessible property value.

## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing <!-- Required -->

<!-- If applicable, add specific steps for the reviewer to perform as part of their testing process prior to approving this pull request. -->

<!-- List any configuration requirements for testing. -->

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [x] Code changes review
- [ ] Documentation changes review
- [x] Unit tests pass
- [x] Static analysis passes