### PR TITLE
Add setInaccessiblePropertyValue helper method and update docs

### DIFF
--- a/docs/tools/wp-mock-test-case.md
+++ b/docs/tools/wp-mock-test-case.md
@@ -122,7 +122,7 @@ final class MyTestCase extends TestCase
 
 #### Handle inaccessible properties
 
-Similar to the methods above, there is a similar collection of test methods that will use `ReflectionProperty` to manipulate inaccessible (private or protected) class properties:
+Similar to the methods above, there is a similar collection of test methods that will use [`ReflectionProperty`](https://www.php.net/manual/en/class.reflectionproperty.php) to manipulate inaccessible (private or protected) class properties:
 
 ```php
 use WP_Mock\Tools\TestCase as TestCase;

--- a/docs/tools/wp-mock-test-case.md
+++ b/docs/tools/wp-mock-test-case.md
@@ -97,7 +97,7 @@ The following methods can be used to access methods or properties of classes tha
 
 #### Get or invoke an inaccessible method
 
-Use the following methods to get and invoke an inaccessible (private or protected) method from a class through `ReflectionMethod`:
+Use the following methods to get and invoke an inaccessible (private or protected) method from a class through [`ReflectionMethod`](https://www.php.net/manual/en/class.reflectionmethod.php):
 
 ```php
 use WP_Mock\Tools\TestCase as TestCase;

--- a/docs/tools/wp-mock-test-case.md
+++ b/docs/tools/wp-mock-test-case.md
@@ -90,3 +90,63 @@ final class MyTestCase extends TestCase
     }   
 }
 ```
+
+### Access inaccessible class members
+
+The following methods can be used to access methods or properties of classes that are inaccessible (private or protected), using reflection:
+
+#### Get or invoke an inaccessible method
+
+Use the following methods to get and invoke an inaccessible (private or protected) method from a class through `ReflectionMethod`:
+
+```php
+use WP_Mock\Tools\TestCase as TestCase;
+
+final class MyTestCase extends TestCase
+{
+    public function testMyFunction() : void
+    {
+        $class = new MyClass();
+    
+        // myMethod() is private or protected - this will return a ReflectionMethod object
+        $method = $this->getInaccessibleMethod($class, 'myMethod');
+        
+        // will invoke MyClass::myMethod()
+        $method->invoke($class);
+        
+        // shortcut method to consolidate the above in a single call (assumes this method returns a string)
+        $this->assertEquals('test', $this->invokeInaccessibleMethod($class, 'myMethod'));
+    }   
+}
+```
+
+#### Handle inaccessible properties
+
+Similar to the methods above, there is a similar collection of test methods that will use `ReflectionProperty` to manipulate inaccessible (private or protected) class properties:
+
+```php
+use WP_Mock\Tools\TestCase as TestCase;
+
+final class MyTestCase extends TestCase
+{
+    public function testMyProperty() : void
+    {
+        $class = MyClass();
+    
+        // $myProperty is private or protected - this will return a ReflectionProperty object
+        $property = $this->getInaccessibleProperty($class, 'myProperty');
+        
+        // invoke MyClass::$myProperty 
+        $this->assertEquals('foo', $property->getValue($class));
+        
+        // shortcut method to consolidate the above in a single call
+        $this->assertEquals('foo', $this->getInaccessiblePropertyValue($class, 'myProperty'));
+        
+        // set MyClass::$myProperty to 'bar'
+        $this->setInaccessibleProperty($class, 'myProperty', 'bar');
+        
+        // shortcut for the above
+        $this->setInaccessiblePropertyValue($class, 'myProperty', 'bar');
+    }   
+}
+```

--- a/docs/tools/wp-mock-test-case.md
+++ b/docs/tools/wp-mock-test-case.md
@@ -93,7 +93,7 @@ final class MyTestCase extends TestCase
 
 ### Access inaccessible class members
 
-The following methods can be used to access methods or properties of classes that are inaccessible (private or protected), using reflection:
+The following methods can be used to access methods or properties of classes that are inaccessible (private or protected), using [Reflection](https://www.php.net/manual/en/book.reflection.php):
 
 #### Get or invoke an inaccessible method
 

--- a/docs/tools/wp-mock-test-case.md
+++ b/docs/tools/wp-mock-test-case.md
@@ -143,7 +143,7 @@ final class MyTestCase extends TestCase
         $this->assertEquals('foo', $this->getInaccessiblePropertyValue($class, 'myProperty'));
         
         // set MyClass::$myProperty to 'bar'
-        $this->setInaccessibleProperty($class, 'myProperty', 'bar');
+        $this->setInaccessibleProperty($class, get_class($class), 'myProperty', 'bar');
         
         // shortcut for the above
         $this->setInaccessiblePropertyValue($class, 'myProperty', 'bar');

--- a/php/WP_Mock/Traits/AccessInaccessibleClassMembersTrait.php
+++ b/php/WP_Mock/Traits/AccessInaccessibleClassMembersTrait.php
@@ -101,4 +101,18 @@ trait AccessInaccessibleClassMembersTrait
 
         return $property;
     }
+
+    /**
+     * Sets a private or protected property on a class.
+     *
+     * @param object $instance class instance
+     * @param string $property the property to set
+     * @param mixed $value the value to set on the property
+     * @return ReflectionProperty
+     * @throws ReflectionException
+     */
+    public function setInaccessiblePropertyValue(object $instance, string $property, $value) : ReflectionProperty
+    {
+        return $this->setInaccessibleProperty($instance, get_class($instance), $property, $value);
+    }
 }

--- a/tests/Unit/WP_Mock/FunctionsTest.php
+++ b/tests/Unit/WP_Mock/FunctionsTest.php
@@ -82,6 +82,9 @@ final class FunctionsTest extends WP_MockTestCase
     /**
      * @covers \WP_Mock\Functions::register()
      *
+     * @preserveGlobalState disabled
+     * @runInSeparateProcess
+     *
      * @return void
      * @throws Exception
      */

--- a/tests/Unit/WP_Mock/Traits/AccessInaccessibleClassMembersTraitTest.php
+++ b/tests/Unit/WP_Mock/Traits/AccessInaccessibleClassMembersTraitTest.php
@@ -45,6 +45,7 @@ final class AccessInaccessibleClassMembersTraitTest extends TestCase
      * @covers \WP_Mock\Traits\AccessInaccessibleClassMembersTrait::setInaccessiblePropertyValue()
      *
      * @return void
+     * @throws ReflectionException|Exception
      */
     public function testCanSetInaccessiblePropertyValue() : void
     {

--- a/tests/Unit/WP_Mock/Traits/AccessInaccessibleClassMembersTraitTest.php
+++ b/tests/Unit/WP_Mock/Traits/AccessInaccessibleClassMembersTraitTest.php
@@ -42,6 +42,19 @@ final class AccessInaccessibleClassMembersTraitTest extends TestCase
     }
 
     /**
+     * @covers \WP_Mock\Traits\AccessInaccessibleClassMembersTrait::setInaccessiblePropertyValue()
+     *
+     * @return void
+     */
+    public function testCanSetInaccessiblePropertyValue() : void
+    {
+        $instance = $this->getInstance('foo');
+        $property = $instance->setInaccessiblePropertyValue($instance, 'property', 'bar');
+
+        $this->assertEquals('bar', $property->getValue($instance));
+    }
+
+    /**
      * @covers \WP_Mock\Traits\AccessInaccessibleClassMembersTrait::getInaccessiblePropertyValue()
      *
      * @return void


### PR DESCRIPTION
# Summary <!-- Required -->

While adding https://github.com/10up/wp_mock/pull/220 I forgot one method (for @10up/godaddy-wp_mock these are basically the same as in MWC Tests, and with the addition of this PR we can drop them -- figured these are generally helpful and could be part of WP_Mock directly).

This PR also updates the docs related to `AccessInaccessibleClassMembersTrait`.

Fixes an unrelated flaky test.

## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing <!-- Required -->

<!-- If applicable, add specific steps for the reviewer to perform as part of their testing process prior to approving this pull request. -->

<!-- List any configuration requirements for testing. -->

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes