### PR TITLE
Fixes a bug that causes a responder not to run the intercepted method while testing an hook that uses a closure + other minor fixes

### DIFF
--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -289,7 +289,7 @@ class WP_Mock
      * Really just a wrapper function for expectHookAdded()
      *
      * @param string   $action   The action name
-     * @param callable $callback The callback that should be registered
+     * @param callable|\Mockery\Matcher\Type $callback The callback that should be registered
      * @param int      $priority The priority it should be registered at
      * @param int      $args     The number of arguments that should be allowed
      */
@@ -303,7 +303,7 @@ class WP_Mock
      * around the expectHookNotAdded function.
      *
      * @param string   $action   The action hook name
-     * @param callable $callback The action callback
+     * @param callable|\Mockery\Matcher\Type $callback The action callback
      */
     public static function expectActionNotAdded($action, $callback)
     {
@@ -316,7 +316,7 @@ class WP_Mock
      * Really just a wrapper function for expectHookAdded()
      *
      * @param string   $filter   The action name
-     * @param callable $callback The callback that should be registered
+     * @param callable|\Mockery\Matcher\Type $callback The callback that should be registered
      * @param int      $priority The priority it should be registered at
      * @param int      $args     The number of arguments that should be allowed
      */
@@ -330,7 +330,7 @@ class WP_Mock
      * around the expectHookNotAdded function.
      *
      * @param string   $filter   The filter hook name
-     * @param callable $callback The filter callback
+     * @param callable|\Mockery\Matcher\Type $callback The filter callback
      */
     public static function expectFilterNotAdded($filter, $callback)
     {
@@ -342,7 +342,7 @@ class WP_Mock
      *
      * @param string   $type     The type of hook being added
      * @param string   $action   The action name
-     * @param callable $callback The callback that should be registered
+     * @param callable|\Mockery\Matcher\Type $callback The callback that should be registered
      * @param int      $priority The priority it should be registered at
      * @param int      $args     The number of arguments that should be allowed
      */
@@ -363,7 +363,7 @@ class WP_Mock
      *
      * @param string   $type     The hook type, 'action' or 'filter'
      * @param string   $action   The name of the hook
-     * @param callable $callback The hooks callback handler.
+     * @param callable|\Mockery\Matcher\Type $callback The hooks callback handler.
      */
     public static function expectHookNotAdded($type, $action, $callback)
     {

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -11,6 +11,7 @@ use Mockery\Exception as MockeryException;
 use WP_Mock\DeprecatedMethodListener;
 use WP_Mock\Functions\Handler;
 use WP_Mock\Matcher\FuzzyObject;
+use Mockery\Matcher\Type;
 
 /**
  * WP_Mock main class.
@@ -289,7 +290,7 @@ class WP_Mock
      * Really just a wrapper function for expectHookAdded()
      *
      * @param string   $action   The action name
-     * @param callable|\Mockery\Matcher\Type $callback The callback that should be registered
+     * @param callable|Type $callback The callback that should be registered
      * @param int      $priority The priority it should be registered at
      * @param int      $args     The number of arguments that should be allowed
      */
@@ -303,7 +304,7 @@ class WP_Mock
      * around the expectHookNotAdded function.
      *
      * @param string   $action   The action hook name
-     * @param callable|\Mockery\Matcher\Type $callback The action callback
+     * @param callable|Type $callback The action callback
      */
     public static function expectActionNotAdded($action, $callback)
     {
@@ -316,7 +317,7 @@ class WP_Mock
      * Really just a wrapper function for expectHookAdded()
      *
      * @param string   $filter   The action name
-     * @param callable|\Mockery\Matcher\Type $callback The callback that should be registered
+     * @param callable|Type $callback The callback that should be registered
      * @param int      $priority The priority it should be registered at
      * @param int      $args     The number of arguments that should be allowed
      */
@@ -330,7 +331,7 @@ class WP_Mock
      * around the expectHookNotAdded function.
      *
      * @param string   $filter   The filter hook name
-     * @param callable|\Mockery\Matcher\Type $callback The filter callback
+     * @param callable|Type $callback The filter callback
      */
     public static function expectFilterNotAdded($filter, $callback)
     {
@@ -342,7 +343,7 @@ class WP_Mock
      *
      * @param string   $type     The type of hook being added
      * @param string   $action   The action name
-     * @param callable|\Mockery\Matcher\Type $callback The callback that should be registered
+     * @param callable|Type $callback The callback that should be registered
      * @param int      $priority The priority it should be registered at
      * @param int      $args     The number of arguments that should be allowed
      */
@@ -363,7 +364,7 @@ class WP_Mock
      *
      * @param string   $type     The hook type, 'action' or 'filter'
      * @param string   $action   The name of the hook
-     * @param callable|\Mockery\Matcher\Type $callback The hooks callback handler.
+     * @param callable|Type $callback The hooks callback handler.
      */
     public static function expectHookNotAdded($type, $action, $callback)
     {

--- a/php/WP_Mock/Hook.php
+++ b/php/WP_Mock/Hook.php
@@ -41,16 +41,27 @@ abstract class Hook
     {
         if (null === $value) {
             return 'null';
-        /** the following is to prevent a possible return mismatch when {@see \WP_Mock\Functions::type()} is used with 'callable' */
-        } elseif ($value instanceof Closure || Closure::class === $value || (is_string($value) && '<CLOSURE>' === strtoupper($value))) {
+        }
+
+        /** the following is to prevent a possible return mismatch when {@see \WP_Mock\Functions::type()} is used with 'callable' and to correctly create safe offsets for processors when expecting, via {@see WP_Mock\Functions::type(\Closure::class)}, that a hook that uses a closure is added*/
+        $closure = fn() => null;
+        if ($value instanceof Closure || Closure::class === $value || (is_string($value) && '<CLOSURE>' === strtoupper($value)) || ($value instanceof \Mockery\Matcher\Type && $value->match($closure))){
             return '__CLOSURE__';
-        } elseif (is_scalar($value)) {
+        }
+        
+        if (is_scalar($value)){
             return (string) $value;
-        } elseif ($value instanceof AnyInstance) {
+        }
+        
+        if ($value instanceof AnyInstance){
             return (string) $value;
-        } elseif (is_object($value)) {
+        }
+        
+        if (is_object($value)){
             return spl_object_hash($value);
-        } elseif (is_array($value)) {
+        }
+        
+        if (is_array($value)) {
             $parsed = '';
 
             foreach ($value as $k => $v) {

--- a/php/WP_Mock/Hook.php
+++ b/php/WP_Mock/Hook.php
@@ -6,6 +6,7 @@ use Closure;
 use PHPUnit\Framework\ExpectationFailedException;
 use WP_Mock;
 use WP_Mock\Matcher\AnyInstance;
+use Mockery\Matcher\Type;
 
 /**
  * Abstract mock representation of a WordPress hook.

--- a/php/WP_Mock/Hook.php
+++ b/php/WP_Mock/Hook.php
@@ -43,9 +43,12 @@ abstract class Hook
             return 'null';
         }
 
-        /** the following is to prevent a possible return mismatch when {@see \WP_Mock\Functions::type()} is used with 'callable' and to correctly create safe offsets for processors when expecting, via {@see WP_Mock\Functions::type(\Closure::class)}, that a hook that uses a closure is added*/
+        /**
+         * The following is to prevent a possible return mismatch when {@see Functions::type()} is used with `callable`,
+         * and to correctly create safe offsets for processors when expecting that a hook that uses a closure is added via {@see Functions::type(Closure::class)}.
+         */
         $closure = fn() => null;
-        if ($value instanceof Closure || Closure::class === $value || (is_string($value) && '<CLOSURE>' === strtoupper($value)) || ($value instanceof \Mockery\Matcher\Type && $value->match($closure))){
+        if ($value instanceof Closure || Closure::class === $value || (is_string($value) && '<CLOSURE>' === strtoupper($value)) || ($value instanceof Type && $value->match($closure))){
             return '__CLOSURE__';
         }
         

--- a/php/WP_Mock/HookedCallback.php
+++ b/php/WP_Mock/HookedCallback.php
@@ -19,7 +19,7 @@ class HookedCallback extends Hook
 
     public function react($callback, $priority, $argument_count)
     {
-        \WP_Mock::addHook($this->name);
+        \WP_Mock::addHook($this->name, $this->type);
 
         $safe_callback = $this->safe_offset($callback);
 

--- a/tests/Unit/WP_Mock/HookTest.php
+++ b/tests/Unit/WP_Mock/HookTest.php
@@ -54,6 +54,7 @@ final class HookTest extends TestCase
         yield 'closure (object)' => [$closureInstance, '__CLOSURE__'];
         yield 'closure (representation)' => ['<Closure>', '__CLOSURE__'];
         yield 'closure (class name)' => [Closure::class, '__CLOSURE__'];
+        yield 'mockery matcher' => [\Mockery::type(\Closure::class), '__CLOSURE__'];
         yield 'scalar (string)' => ['test-string', 'test-string'];
         yield 'scalar (integer)' => [123, '123'];
         yield 'scalar (float)' => [1.23, '1.23'];

--- a/tests/Unit/WP_Mock/HookTest.php
+++ b/tests/Unit/WP_Mock/HookTest.php
@@ -54,7 +54,7 @@ final class HookTest extends TestCase
         yield 'closure (object)' => [$closureInstance, '__CLOSURE__'];
         yield 'closure (representation)' => ['<Closure>', '__CLOSURE__'];
         yield 'closure (class name)' => [Closure::class, '__CLOSURE__'];
-        yield 'mockery matcher' => [\Mockery::type(\Closure::class), '__CLOSURE__'];
+        yield 'closure (Mockery matcher)' => [Mockery::type(Closure::class), '__CLOSURE__'];
         yield 'scalar (string)' => ['test-string', 'test-string'];
         yield 'scalar (integer)' => [123, '123'];
         yield 'scalar (float)' => [1.23, '1.23'];

--- a/tests/Unit/WP_Mock/HookTest.php
+++ b/tests/Unit/WP_Mock/HookTest.php
@@ -5,6 +5,7 @@ namespace WP_Mock\Tests\Unit\WP_Mock;
 use Closure;
 use Generator;
 use Exception;
+use Mockery;
 use PHPUnit\Framework\TestCase;
 use ReflectionException;
 use stdClass;


### PR DESCRIPTION
<!--
Filling out the required portions of this template is mandatory. 
Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.
All new code requires associated documentation and unit tests.
-->

# Summary <!-- Required -->

WP_Mock::expect* functions now are correctly annotated to accept an Instance of \Mockery\Mathcer\Type
Fixed a bug in Hook::safe_offset that caused \Mockery\Matcher\Type::(\Closure::class) objects to be treated as other objects. Now they correctly return __CLOSURE__, in order to test that hooks that use closures are added. Added a provider entry to the relative unit test to ensure the correct behavior. Fixed a bug in HookedCallback::react that caused all the hooks added via \WP_Mock::addHook to be added as filters. Now the correct type is passed.

### Closes: Does not close any open issue

## Details <!-- Optional -->

I was testing an action that uses a closure. Even if I used the same line as the documentation, I was getting an error on a Mockery instance that I never created. I found out it was the one created inside WP_Mock::expectActionAdded, that checks if the interceptor method has been executed. Well, it was not getting executed because the processor array key for this Mockery\Matcher\Type instance was the hash of the object itself and not the string __CALLABLE__ as it is expected. I added an additional check in the  Hook::safe_offset in order to prevent this behavior, the $callback variable you will see is used by Mockery\Matcher\Type to ensure that the callable is actually a closure, it's the only way I found since the parameter is passed by reference. While working on it, I noticed that in HookedCallback::react the call to \WP_Mock::addHook was not passing the type as a parameter, causing all the hooks to be registered as a filter (which is the default value), so I added the type parameter. Lastly I added to the WP_Mock::expect* functions the appropriate PHPDoc to hint the IDEs that these methods can also accept a \Mockery\Matcher\Type instance. I also updated the Hook test data provider to test the case I described above.
Lastly, sorry for my English and if I'm doing something wrong, it's my absolute first pull request :)

PS: I would like, if possible, to contribute further to make this package compatible with PHPUnit 10.x


## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [X] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [X] I have updated the documentation accordingly 
- [X] I have added tests to cover changes introduced by this pull request
- [X] All new and existing tests pass

## Testing <!-- Required -->

<!-- If applicable, add specific steps for the reviewer to perform as part of their testing process prior to approving this pull request. -->

<!-- List any configuration requirements for testing. -->

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [x] Code changes review
- [ ] Documentation changes review
- [x] Unit tests pass
- [x] Static analysis passes