### PR TITLE
Update return type for mockPost()

### DIFF
--- a/php/WP_Mock/Traits/MockWordPressObjectsTrait.php
+++ b/php/WP_Mock/Traits/MockWordPressObjectsTrait.php
@@ -3,6 +3,8 @@
 namespace WP_Mock\Traits;
 
 use Mockery;
+use Mockery\LegacyMockInterface;
+use Mockery\MockInterface;
 use WP;
 use WP_Post;
 
@@ -14,12 +16,18 @@ trait MockWordPressObjectsTrait
     /**
      * Mocks a WordPress post.
      *
+     * Users of this method should add `@var WP_Post $variable` or `@var Mockery\MockInterface $variable` to
+     * set the necessary type for the resulting mock. Unfortunately, PHPStan doesn't allow WP_Post in an
+     * intersection type, because the class is marked as final.
+     *
      * @param array<string, mixed> $postData optional post data to add to the post
-     * @return WP_Post&Mockery\MockInterface&Mockery\LegacyMockInterface
+     * @return Mockery\LegacyMockInterface&Mockery\MockInterface
      */
     protected function mockPost(array $postData = [])
     {
+        /** @var Mockery\LegacyMockInterface&Mockery\MockInterface $post */
         $post = Mockery::mock(WP_Post::class);
+
         $postData = array_merge([
             'ID'                => 0,
             'post_author'       => 0,

--- a/php/WP_Mock/Traits/MockWordPressObjectsTrait.php
+++ b/php/WP_Mock/Traits/MockWordPressObjectsTrait.php
@@ -60,10 +60,11 @@ trait MockWordPressObjectsTrait
      * Mocks a WordPress instance.
      *
      * @param array<string, mixed> $queryVars
-     * @return Mockery\LegacyMockInterface|Mockery\MockInterface|WP|(WP&Mockery\LegacyMockInterface)|(WP&Mockery\MockInterface)
+     * @return WP&LegacyMockInterface&MockInterface
      */
     protected function mockWp(array $queryVars = [])
     {
+        /** @var WP&Mockery\LegacyMockInterface&Mockery\MockInterface $wp */
         $wp = Mockery::mock(WP::class);
         /** @phpstan-ignore-next-line */
         $wp->query_vars = $queryVars;

--- a/php/WP_Mock/Traits/MockWordPressObjectsTrait.php
+++ b/php/WP_Mock/Traits/MockWordPressObjectsTrait.php
@@ -15,7 +15,7 @@ trait MockWordPressObjectsTrait
      * Mocks a WordPress post.
      *
      * @param array<string, mixed> $postData optional post data to add to the post
-     * @return Mockery\LegacyMockInterface|Mockery\MockInterface|WP_Post|(WP_Post&Mockery\LegacyMockInterface)|(WP_Post&Mockery\MockInterface)
+     * @return WP_Post&Mockery\MockInterface&Mockery\LegacyMockInterface
      */
     protected function mockPost(array $postData = [])
     {


### PR DESCRIPTION
# Summary <!-- Required -->

The return type must be a `WP_Post` and a mockery mock at the same time. I believe that the method needs to use an intersection type instead of an union one.

## Details

Unfortunately, `WP_Post` cannot be used in an intersection type, because the class is declared as final ([related discussions in PHPStan's repo](https://github.com/phpstan/phpstan/issues/8901)). The current version of `mockPost()` was always returning `Mockery\LegacyMockInterface` so I think it still makes sense to update the return type.

I also updated the return type of `mockWp()` to return an intersection of `WP` and Mockery mock interfaces. Since `WP` is not final, we can use the intersection type directly.

## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly 
- [ ] I have added tests to cover changes introduced by this pull request
- [ ] All new and existing tests pass

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes