### PR TITLE
Modify type of $args parameter

### DIFF
--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -427,7 +427,7 @@ class WP_Mock
      * It is possible to use Mockery methods to add expectations to the object returned, which will then be combined with any expectations that may have been passed as arguments.
      *
      * @param string $function function name
-     * @param array<string, mixed> $args optional arguments to set expectations
+     * @param mixed[] $args optional arguments to set expectations
      * @return Mockery\Expectation
      * @throws InvalidArgumentException
      */
@@ -446,7 +446,7 @@ class WP_Mock
      *    esc_attr_e('some_value'); // echoes "some_value"
      *
      * @param string $function function name
-     * @param array<string, mixed>|scalar $args optional arguments
+     * @param mixed[]|scalar $args optional arguments
      * @return Mockery\Expectation
      * @throws InvalidArgumentException
      */
@@ -471,7 +471,7 @@ class WP_Mock
      *    echo esc_attr('some_value'); // echoes "some_value"
      *
      * @param string $function function name
-     * @param array<string, mixed>|scalar $args function arguments (optional)
+     * @param mixed[]|scalar $args function arguments (optional)
      * @return Mockery\Expectation
      * @throws InvalidArgumentException
      */
@@ -493,7 +493,7 @@ class WP_Mock
      *
      * @param string|callable-string $function function to alias
      * @param string|callable-string $aliasFunction actual function
-     * @param array<int|string, mixed>|scalar $args optional arguments
+     * @param mixed[]|scalar $args optional arguments
      * @return Mockery\Expectation
      * @throws InvalidArgumentException
      */


### PR DESCRIPTION
# Summary <!-- Required -->

Modifies the type of the `$args` parameter to be `mixed[]`. The array of arguments is unlikely to have `string` keys. `mixed[]` allows both positional and associative arrays as the list of arguments.

## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly 
- [ ] I have added tests to cover changes introduced by this pull request
- [ ] All new and existing tests pass

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes