### PR TITLE
Update docs to explain how WP_Mock TestCase is preferable to extend than PhpUnit's

### DIFF
--- a/docs/general/configuration.md
+++ b/docs/general/configuration.md
@@ -42,7 +42,7 @@ A more convenient way though would be to add the following to the phpunit.xml co
 bootstrap="/path/to/bootstrap.php"
 ```
 
-## Patchwork
+## Enable Patchwork
 
 [Patchwork](https://github.com/antecedent/patchwork) is a library that enables temporarily overwriting user-defined functions and static methods. This means you can better isolate your system under test by mocking your plugin's functions that are tested elsewhere. If Patchwork is turned on, WP_Mock will transparently use it behind the scenes. For most use cases, you won't need to worry about using it directly.
 
@@ -53,7 +53,7 @@ WP_Mock::setUsePatchwork(true);
 WP_Mock::bootstrap();
 ```
 
-## Strict Mode
+## Enable Strict Mode
 
 WP_Mock has a strict mode that developers may optionally enable. By default, it is disabled. If enabled, strict mode will cause tests to fail if they use previously mocked functions without first explicitly declaring an expectation for how that function will be used. This provides an easy way to enforce an extra layer of specificity in unit tests. 
 
@@ -62,4 +62,46 @@ Like using patchwork, strict mode has to be enabled before the WP_Mock framework
 ```php
 WP_Mock::activateStrictMode();
 WP_Mock::bootstrap();
+```
+
+## Extend WP_Mock Test Case
+
+Once you have set up WP_Mock as outlined above, you should use the `WP_Mock\Tools\TestCase` class as your base test case class in your PHPUnit tests. This class extends PHPUnit's own `TestCase` class, with some helper methods but also methods that help WP_Mock to function properly. You should always extend `WP_Mock\Tools\TestCase` instead of `PHPUnit\Framework\TestCase` when using WP_Mock.
+
+```php
+
+use WP_Mock\Tools\TestCase;
+
+class MyClassTest extends TestCase
+{
+    // your test methods   
+}
+
+```
+
+If you **do not** wish to extend WP_Mock own test case, then you should make sure to call `WP_Mock::setUp()` and `WP_Mock::tearDown()` in your test case's `setUp()` and `tearDown()` methods respectively. This is not recommended though.
+
+```php
+
+use PHPUnit\Framework\TestCase;
+
+class MyClassTest extends TestCase
+{
+    public function setUp() : void
+    {
+        parent::setUp()
+
+        WP_Mock::setUp();
+    }
+
+    public function tearDown() : void
+    {
+        parent::tearDown();
+
+        WP_Mock::tearDown();
+    }
+
+    // your test methods   
+}
+
 ```

--- a/docs/general/configuration.md
+++ b/docs/general/configuration.md
@@ -66,7 +66,7 @@ WP_Mock::bootstrap();
 
 ## Extend WP_Mock Test Case
 
-Once you have set up WP_Mock as outlined above, you should use the `WP_Mock\Tools\TestCase` class as your base test case class in your PHPUnit tests. This class extends PHPUnit's own `TestCase` class, with some helper methods but also methods that help WP_Mock to function properly. You should always extend `WP_Mock\Tools\TestCase` instead of `PHPUnit\Framework\TestCase` when using WP_Mock.
+Once you have followed the configuration steps as outlined above, you'll want to update your test classes to extend the `WP_Mock\Tools\TestCase` class for the best results when using WP_Mock. This class extends PHPUnit's own `TestCase` class, with some helper and other methods that help WP_Mock to function properly.
 
 ```php
 

--- a/docs/general/installation.md
+++ b/docs/general/installation.md
@@ -25,4 +25,4 @@ They will be installed for you by Composer.
 
 Next, you will need to configure PHPUnit first before enabling WP_Mock. [Consult PHPUnit documentation](https://phpunit.de/documentation.html) for this step.
 
-You will also need to configure WP_Mock with a bootstrap file to use it in your tests.
+You will also need to [configure WP_Mock with a bootstrap file](configuration.md) to use it in your tests.

--- a/docs/usage/mocking-wp-objects.md
+++ b/docs/usage/mocking-wp-objects.md
@@ -24,9 +24,8 @@ When we mock the `$wpdb` object, we're not performing an actual database call, o
 ```php
 use Mockery;
 use MyPlugin\MyClass;
-use PHPUnit\Framework\TestCase;
 
-final class MyClassTest extends TestCase
+final class MyClassTest extends \WP_Mock\Tools\TestCase
 {
     public function testCanGetSomePostIds() : void
     {

--- a/docs/usage/using-wp-mock.md
+++ b/docs/usage/using-wp-mock.md
@@ -59,9 +59,9 @@ return \WP_Mock\Functions\Handler::handleFunction(__FUNCTION__, func_get_args())
 
 **Important!**
 
-Note how in the above test class `WP_Mock\Tools\TestCase` was extended instead of `PHPUnit\Framework\TestCase`. This is because WP_Mock provides a custom test case class that extends PHPUnit's test case class and adds additional functionality to it. Ideally, you should always extend `WP_Mock\Tools\TestCase` instead of `PHPUnit\Framework\TestCase` when using WP_Mock. _If you do not wish to extend WP_Mock own test case class_ you should make sure to call `WP_Mock::setUp()` and `WP_Mock::tearDown()` in your test case's `setUp()` and `tearDown()` methods respectively.
+Note how in the above test class `WP_Mock\Tools\TestCase` was extended instead of `PHPUnit\Framework\TestCase`. This is because WP_Mock provides a custom test case class that extends PHPUnit's test case class to run properly, as well as while adding additional utility and test methods. You should always extend `WP_Mock\Tools\TestCase` instead of `PHPUnit\Framework\TestCase` when using WP_Mock.
 
-See [WP_Mock Test Case Documentation](../tools/wp-mock-test-case.md)
+See [WP_Mock Test Case Documentation](../tools/wp-mock-test-case.md) and [how to configure WP_Mock](../general/configuration.md) for more information.
 
 {% endhint %}
 

--- a/docs/usage/using-wp-mock.md
+++ b/docs/usage/using-wp-mock.md
@@ -26,11 +26,10 @@ You can use `WP_Mock::userFunction()` to mock the `get_post()` function and retu
 
 ```php
 use MyPlugin\MyClass;
-use PHPUnit\Framework\TestCase;
 use stdClass
 use WP_Mock;
 
-final class MyClassTest extends TestCase
+final class MyClassTest extends WP_Mock\Tools\TestCase
 {
     public function testMyFunction() : void
     {
@@ -54,6 +53,10 @@ Calling `WP_Mock::userFunction()` will dynamically define the function for you i
 ```php
 return \WP_Mock\Functions\Handler::handleFunction(__FUNCTION__, func_get_args());
 ```
+
+**Important!**
+
+Note how in the above test class `WP_Mock\Tools\TestCase` was extended instead of `PHPUnit\Framework\TestCase`. This is because WP_Mock provides a custom test case class that extends PHPUnit's test case class and adds additional functionality to it. Ideally, you should always extend `WP_Mock\Tools\TestCase` instead of `PHPUnit\Framework\TestCase` when using WP_Mock. _If you do not wish to extend WP_Mock own test case class_ you should make sure to call `WP_Mock::setUp()` and `WP_Mock::tearDown()` in your test case's `setUp()` and `tearDown()` methods respectively.
 
 ## Using Mockery expectations
 

--- a/docs/usage/using-wp-mock.md
+++ b/docs/usage/using-wp-mock.md
@@ -59,8 +59,7 @@ return \WP_Mock\Functions\Handler::handleFunction(__FUNCTION__, func_get_args())
 
 **Important!**
 
-Note how in the above test class `WP_Mock\Tools\TestCase` was extended instead of `PHPUnit\Framework\TestCase`. This is because WP_Mock provides a custom test case class that extends PHPUnit's test case class to run properly, as well as while adding additional utility and test methods. You should always extend `WP_Mock\Tools\TestCase` instead of `PHPUnit\Framework\TestCase` when using WP_Mock.
-
+You should typically extend `WP_Mock\Tools\TestCase` instead of `PHPUnit\Framework\TestCase` when using WP_Mock.
 See [WP_Mock Test Case Documentation](../tools/wp-mock-test-case.md) and [how to configure WP_Mock](../general/configuration.md) for more information.
 
 {% endhint %}

--- a/docs/usage/using-wp-mock.md
+++ b/docs/usage/using-wp-mock.md
@@ -54,9 +54,16 @@ Calling `WP_Mock::userFunction()` will dynamically define the function for you i
 return \WP_Mock\Functions\Handler::handleFunction(__FUNCTION__, func_get_args());
 ```
 
+
+{% hint style="warning" %}
+
 **Important!**
 
 Note how in the above test class `WP_Mock\Tools\TestCase` was extended instead of `PHPUnit\Framework\TestCase`. This is because WP_Mock provides a custom test case class that extends PHPUnit's test case class and adds additional functionality to it. Ideally, you should always extend `WP_Mock\Tools\TestCase` instead of `PHPUnit\Framework\TestCase` when using WP_Mock. _If you do not wish to extend WP_Mock own test case class_ you should make sure to call `WP_Mock::setUp()` and `WP_Mock::tearDown()` in your test case's `setUp()` and `tearDown()` methods respectively.
+
+See [WP_Mock Test Case Documentation](../tools/wp-mock-test-case.md)
+
+{% endhint %}
 
 ## Using Mockery expectations
 


### PR DESCRIPTION
<!--
Filling out the required portions of this template is mandatory. 
Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.
All new code requires associated documentation and unit tests.
-->

# Summary <!-- Required -->

Updates docs to make it clear that implementations should use WP_Mock own `TestCase`, ideally, or at least provide teardown overrides.

### Closes: #238 

## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass
### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Doc examples should always reference WP_Mock own `TestCase`
- [ ] Unit tests pass
- [ ] Static analysis passes