### PR TITLE
Restore composer version for Packagist

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "10up/wp_mock",
     "description": "A mocking library to take the pain out of unit testing for WordPress",
+    "version": "1.0.1",
     "license": "BSD-3-Clause",
     "prefer-stable": true,
     "require": {


### PR DESCRIPTION
# Summary <!-- Required -->

In https://github.com/10up/wp_mock/pull/242 we removed the `version` from `composer.json` in the hopes of fixing #241  however it seem having had no effect. The assumption was packagist should have read from git tags instead (which list 1.0.1 correctly). Maybe this has to do with packagist configuration, to which I have no access to as of yet.

### Closes: #243 
 

## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing <!-- Required -->

No code change.

<!-- List any configuration requirements for testing. -->

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes