### PR TITLE
Add convenience `::expectFilterRemoved()` `::expectActionRemoved()` Fix #157

### DIFF
--- a/docs/usage/mocking-wp-action-and-filter-hooks.md
+++ b/docs/usage/mocking-wp-action-and-filter-hooks.md
@@ -141,3 +141,24 @@ final class MyClassTest extends TestCase
     }
 }
 ```
+
+## Asserting that actions and filters have been removed
+
+Similarly, we can test that actions and filters are removed when expected, e.g.removing another plugin's admin notice. This is done using `WP_Mock::expectActionRemoved()` and `WP_Mock::expectFilterRemoved()`. Or conversely, we can confirm that they have _not_ been removed using `WP_Mock::expectActionNotRemoved()` and `WP_Mock::expectFilterNotRemoved()`. The latter functions are useful where a function being tested returns early in some scenarios, and we want to ensure that the hooks are not removed in that case.
+
+```php
+use MyPlugin\MyClass;
+use WP_Mock\Tools\TestCase as TestCase;
+
+final class MyClassTest extends TestCase
+{
+    public function testRemoveAction() : void 
+    {
+        $classInstance = new MyClass();
+    
+        WP_Mock::expectActionRemoved('admin_notices', 'invasive_admin_notice');
+    
+        $classInstance->removeInvasiveAdminNotice();
+    }
+}
+```

--- a/docs/usage/mocking-wp-action-and-filter-hooks.md
+++ b/docs/usage/mocking-wp-action-and-filter-hooks.md
@@ -144,7 +144,7 @@ final class MyClassTest extends TestCase
 
 ## Asserting that actions and filters have been removed
 
-Similarly, we can test that actions and filters are removed when expected, e.g.removing another plugin's admin notice. This is done using `WP_Mock::expectActionRemoved()` and `WP_Mock::expectFilterRemoved()`. Or conversely, we can confirm that they have _not_ been removed using `WP_Mock::expectActionNotRemoved()` and `WP_Mock::expectFilterNotRemoved()`. The latter functions are useful where a function being tested returns early in some scenarios, and we want to ensure that the hooks are not removed in that case.
+Similarly, we can test that actions and filters are removed when expected, e.g.removing another plugin's admin notice. This is done using `WP_Mock::expectActionRemoved()` and `WP_Mock::expectFilterRemoved()`. Or conversely, we can confirm that they have _not_ been removed using `WP_Mock::expectActionNotRemoved()` and `WP_Mock::expectFilterNotRemoved()`. The latter functions are useful where a function being tested returns early in some scenarios, and we want to ensure that the hooks are not removed in that case. NB: omitting the priority does not catch any uses of `remove_action()` that use an explicit priority, for that case consider using `\WP_Mock\Functions::type( 'int' )`.
 
 ```php
 use MyPlugin\MyClass;

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -554,10 +554,10 @@ class WP_Mock
      * @param string|callable-string|callable|Type $callback the callable to be removed
      * @param int|Type|null $priority the priority it should be registered at
      *
-     * @return void
+     * @return Mockery\Expectation
      * @throws InvalidArgumentException
      */
-    public static function expectActionRemoved(string $action, $callback, $priority = null) : void
+    public static function expectActionRemoved(string $action, $callback, ?int $priority = null) : Mockery\Expectation
     {
         self::userFunction(
             'remove_action',

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -552,12 +552,12 @@ class WP_Mock
      *
      * @param string $action the action hook name
      * @param string|callable-string|callable|Type $callback the callable to be removed
-     * @param ?int $priority the priority it should be registered at
+     * @param ?int|Type $priority the priority it should be registered at
      *
      * @return void
      * @throws InvalidArgumentException
      */
-    public static function expectActionRemoved(string $action, $callback, ?int $priority = null) : void
+    public static function expectActionRemoved(string $action, $callback, $priority = null) : void
     {
         self::userFunction(
             'remove_action',
@@ -573,7 +573,7 @@ class WP_Mock
      *
      * @param string $action the action hook name
      * @param null|string|callable-string|callable|Type $callback the callable to be removed
-     * @param ?int $priority optional priority for the registered callback that is being removed
+     * @param ?int|Type $priority optional priority for the registered callback that is being removed
      *
      * @return void
      * @throws InvalidArgumentException
@@ -594,12 +594,12 @@ class WP_Mock
      *
      * @param string $filter the filter name
      * @param string|callable-string|callable|Type $callback the callable to be removed
-     * @param ?int $priority the registered priority
+     * @param ?int|Type $priority the registered priority
      *
      * @return void
      * @throws InvalidArgumentException
      */
-    public static function expectFilterRemoved(string $filter, $callback, ?int $priority = null) : void
+    public static function expectFilterRemoved(string $filter, $callback, $priority = null) : void
     {
         self::userFunction(
             'remove_filter',
@@ -615,7 +615,7 @@ class WP_Mock
      *
      * @param string $filter the filter name
      * @param null|string|callable-string|callable|Type $callback the callable to be removed
-     * @param ?int $priority optional priority for the registered callback that is being removed
+     * @param ?int|Type $priority optional priority for the registered callback that is being removed
      *
      * @return void
      * @throws InvalidArgumentException

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -439,7 +439,7 @@ class WP_Mock
      *
      * @param string $function function name
      * @param mixed[] $args optional arguments to set expectations
-     * @return Mockery\Expectation
+     * @return Mockery\Expectation|Mockery\CompositeExpectation
      * @throws InvalidArgumentException
      */
     public static function userFunction(string $function, array $args = [])
@@ -554,13 +554,13 @@ class WP_Mock
      * @param string|callable-string|callable|Type $callback the callable to be removed
      * @param int|Type|null $priority the priority it should be registered at
      *
-     * @return Mockery\Expectation
+     * @return Mockery\Expectation|Mockery\CompositeExpectation
      * @throws InvalidArgumentException
      */
-    public static function expectActionRemoved(string $action, $callback, ?int $priority = null) : Mockery\Expectation
+    public static function expectActionRemoved(string $action, $callback, $priority = null)
     {
         $args = [$action, $callback];
-        if ($priority) {
+        if (!is_null($priority)) {
             $args[] = $priority;
         }
 
@@ -577,18 +577,20 @@ class WP_Mock
      * @param null|string|callable-string|callable|Type $callback the callable to be removed
      * @param int|Type|null $priority optional priority for the registered callback that is being removed
      *
-     * @return void
+     * @return Mockery\Expectation|Mockery\CompositeExpectation
      * @throws InvalidArgumentException
      */
-    public static function expectActionNotRemoved(string $action, $callback, $priority = null) : void
+    public static function expectActionNotRemoved(string $action, $callback, $priority = null)
     {
-        self::userFunction(
-            'remove_action',
-            array(
-                'args'   => array_filter(func_get_args()),
-                'times'  => 0,
-            )
-        );
+        $args = [$action, $callback];
+        if (!is_null($priority)) {
+            $args[] = $priority;
+        }
+
+        return self::userFunction('remove_action',[
+            'args'   => $args,
+            'times'  => 0,
+        ]);
     }
 
     /**
@@ -598,18 +600,20 @@ class WP_Mock
      * @param string|callable-string|callable|Type $callback the callable to be removed
      * @param int|Type|null $priority the registered priority
      *
-     * @return void
+     * @return Mockery\Expectation|Mockery\CompositeExpectation
      * @throws InvalidArgumentException
      */
-    public static function expectFilterRemoved(string $filter, $callback, $priority = null) : void
+    public static function expectFilterRemoved(string $filter, $callback, $priority = null)
     {
-        self::userFunction(
-            'remove_filter',
-            array(
-                'args'   => array_filter(func_get_args()),
-                'times'  => 1,
-            )
-        );
+        $args = [$filter, $callback];
+        if (!is_null($priority)) {
+            $args[] = $priority;
+        }
+
+        return self::userFunction('remove_filter',[
+            'args'   => $args,
+            'times'  => 1,
+        ]);
     }
 
     /**
@@ -619,17 +623,19 @@ class WP_Mock
      * @param null|string|callable-string|callable|Type $callback the callable to be removed
      * @param int|Type|null $priority optional priority for the registered callback that is being removed
      *
-     * @return void
+     * @return Mockery\Expectation|Mockery\CompositeExpectation
      * @throws InvalidArgumentException
      */
-    public static function expectFilterNotRemoved(string $filter, $callback, $priority = null) : void
+    public static function expectFilterNotRemoved(string $filter, $callback, $priority = null)
     {
-        self::userFunction(
-            'remove_filter',
-            array(
-                'args'   => array_filter(func_get_args()),
-                'times'  => 0,
-            )
-        );
+        $args = [$filter, $callback];
+        if (!is_null($priority)) {
+            $args[] = $priority;
+        }
+
+        return self::userFunction('remove_filter',[
+            'args'   => $args,
+            'times'  => 0,
+        ]);
     }
 }

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -562,9 +562,7 @@ class WP_Mock
         self::userFunction(
             'remove_action',
             array(
-                'args'   => is_int($priority)
-                    ? array($action, $callback, $priority)
-                    : array($action, $callback),
+                'args'   => array_filter(func_get_args()),
                 'times'  => 1,
             )
         );
@@ -585,9 +583,7 @@ class WP_Mock
         self::userFunction(
             'remove_filter',
             array(
-                'args'   => is_int($priority)
-                    ? array($filter, $callback, $priority)
-                    : array($filter, $callback),
+                'args'   => array_filter(func_get_args()),
                 'times'  => 1,
             )
         );

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -459,7 +459,7 @@ class WP_Mock
      *
      * @param string $function function name
      * @param mixed[]|scalar $args optional arguments
-     * @return ExpectationInterface
+     * @return Mockery\Expectation
      * @throws InvalidArgumentException
      */
     public static function echoFunction(string $function, $args = [])
@@ -484,7 +484,7 @@ class WP_Mock
      *
      * @param string $function function name
      * @param mixed[]|scalar $args function arguments (optional)
-     * @return ExpectationInterface
+     * @return Mockery\Expectation
      * @throws InvalidArgumentException
      */
     public static function passthruFunction(string $function, $args = [])
@@ -506,7 +506,7 @@ class WP_Mock
      * @param string|callable-string $function function to alias
      * @param string|callable-string $aliasFunction actual function
      * @param mixed[]|scalar $args optional arguments
-     * @return ExpectationInterface
+     * @return Mockery\Expectation
      * @throws InvalidArgumentException
      */
     public static function alias(string $function, string $aliasFunction, $args = [])

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -559,13 +559,15 @@ class WP_Mock
      */
     public static function expectActionRemoved(string $action, $callback, ?int $priority = null) : Mockery\Expectation
     {
-        self::userFunction(
-            'remove_action',
-            array(
-                'args'   => array_filter(func_get_args()),
-                'times'  => 1,
-            )
-        );
+        $args = [$action, $callback];
+        if ($priority) {
+            $args[] = $priority;
+        }
+
+        return self::userFunction('remove_action', [
+            'args'  => $args,
+            'times' => 1,
+        ]);
     }
 
     /**

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -573,21 +573,21 @@ class WP_Mock
     /**
      * Adds an expectation that a filter should be removed.
      *
-     * @param string $action the filter name
+     * @param string $filter the filter name
      * @param string|callable-string|callable|Type $callback the callable to be removed
      * @param ?int $priority the registered priority
      *
      * @return void
      * @throws InvalidArgumentException
      */
-    public static function expectFilterRemoved(string $action, $callback, ?int $priority = null) : void
+    public static function expectFilterRemoved(string $filter, $callback, ?int $priority = null) : void
     {
         self::userFunction(
             'remove_filter',
             array(
                 'args'   => is_int($priority)
-                    ? array($action, $callback, $priority)
-                    : array($action, $callback),
+                    ? array($filter, $callback, $priority)
+                    : array($filter, $callback),
                 'times'  => 1,
             )
         );

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -8,6 +8,7 @@
  */
 
 use Mockery\Exception as MockeryException;
+use Mockery\ExpectationInterface;
 use WP_Mock\DeprecatedMethodListener;
 use WP_Mock\Functions\Handler;
 use WP_Mock\Matcher\FuzzyObject;
@@ -439,7 +440,7 @@ class WP_Mock
      *
      * @param string $function function name
      * @param mixed[] $args optional arguments to set expectations
-     * @return Mockery\Expectation|Mockery\CompositeExpectation
+     * @return Mockery\Expectation
      * @throws InvalidArgumentException
      */
     public static function userFunction(string $function, array $args = [])
@@ -458,7 +459,7 @@ class WP_Mock
      *
      * @param string $function function name
      * @param mixed[]|scalar $args optional arguments
-     * @return Mockery\Expectation
+     * @return ExpectationInterface
      * @throws InvalidArgumentException
      */
     public static function echoFunction(string $function, $args = [])
@@ -483,7 +484,7 @@ class WP_Mock
      *
      * @param string $function function name
      * @param mixed[]|scalar $args function arguments (optional)
-     * @return Mockery\Expectation
+     * @return ExpectationInterface
      * @throws InvalidArgumentException
      */
     public static function passthruFunction(string $function, $args = [])
@@ -505,7 +506,7 @@ class WP_Mock
      * @param string|callable-string $function function to alias
      * @param string|callable-string $aliasFunction actual function
      * @param mixed[]|scalar $args optional arguments
-     * @return Mockery\Expectation
+     * @return ExpectationInterface
      * @throws InvalidArgumentException
      */
     public static function alias(string $function, string $aliasFunction, $args = [])
@@ -554,7 +555,7 @@ class WP_Mock
      * @param string|callable-string|callable|Type $callback the callable to be removed
      * @param int|Type|null $priority the priority it should be registered at
      *
-     * @return Mockery\Expectation|Mockery\CompositeExpectation
+     * @return ExpectationInterface
      * @throws InvalidArgumentException
      */
     public static function expectActionRemoved(string $action, $callback, $priority = null)
@@ -577,7 +578,7 @@ class WP_Mock
      * @param null|string|callable-string|callable|Type $callback the callable to be removed
      * @param int|Type|null $priority optional priority for the registered callback that is being removed
      *
-     * @return Mockery\Expectation|Mockery\CompositeExpectation
+     * @return ExpectationInterface
      * @throws InvalidArgumentException
      */
     public static function expectActionNotRemoved(string $action, $callback, $priority = null)
@@ -600,7 +601,7 @@ class WP_Mock
      * @param string|callable-string|callable|Type $callback the callable to be removed
      * @param int|Type|null $priority the registered priority
      *
-     * @return Mockery\Expectation|Mockery\CompositeExpectation
+     * @return ExpectationInterface
      * @throws InvalidArgumentException
      */
     public static function expectFilterRemoved(string $filter, $callback, $priority = null)
@@ -623,7 +624,7 @@ class WP_Mock
      * @param null|string|callable-string|callable|Type $callback the callable to be removed
      * @param int|Type|null $priority optional priority for the registered callback that is being removed
      *
-     * @return Mockery\Expectation|Mockery\CompositeExpectation
+     * @return ExpectationInterface
      * @throws InvalidArgumentException
      */
     public static function expectFilterNotRemoved(string $filter, $callback, $priority = null)

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -569,6 +569,27 @@ class WP_Mock
     }
 
     /**
+     * Adds an expectation that an action should not be removed.
+     *
+     * @param string $action the action hook name
+     * @param null|string|callable-string|callable|Type $callback the callable to be removed
+     * @param ?int $priority optional priority for the registered callback that is being removed
+     *
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    public static function expectActionNotRemoved(string $action, $callback, $priority = null) : void
+    {
+        self::userFunction(
+            'remove_action',
+            array(
+                'args'   => array_filter(func_get_args()),
+                'times'  => 0,
+            )
+        );
+    }
+
+    /**
      * Adds an expectation that a filter should be removed.
      *
      * @param string $filter the filter name
@@ -585,6 +606,27 @@ class WP_Mock
             array(
                 'args'   => array_filter(func_get_args()),
                 'times'  => 1,
+            )
+        );
+    }
+
+    /**
+     * Adds an expectation that a filter should not be removed.
+     *
+     * @param string $filter the filter name
+     * @param null|string|callable-string|callable|Type $callback the callable to be removed
+     * @param ?int $priority optional priority for the registered callback that is being removed
+     *
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    public static function expectFilterNotRemoved(string $filter, $callback, $priority = null) : void
+    {
+        self::userFunction(
+            'remove_filter',
+            array(
+                'args'   => array_filter(func_get_args()),
+                'times'  => 0,
             )
         );
     }

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -546,4 +546,50 @@ class WP_Mock
     {
         return static::$deprecatedMethodListener;
     }
+
+    /**
+     * Adds an expectation that an action should be removed.
+     *
+     * @param string $action the action hook name
+     * @param string|callable-string|callable|Type $callback the callable to be removed
+     * @param ?int $priority the priority it should be registered at
+     *
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    public static function expectActionRemoved(string $action, $callback, ?int $priority = null) : void
+    {
+        self::userFunction(
+            'remove_action',
+            array(
+                'args'   => is_int($priority)
+                    ? array($action, $callback, $priority)
+                    : array($action, $callback),
+                'times'  => 1,
+            )
+        );
+    }
+
+    /**
+     * Adds an expectation that a filter should be removed.
+     *
+     * @param string $action the filter name
+     * @param string|callable-string|callable|Type $callback the callable to be removed
+     * @param ?int $priority the registered priority
+     *
+     * @return void
+     * @throws InvalidArgumentException
+     */
+    public static function expectFilterRemoved(string $action, $callback, ?int $priority = null) : void
+    {
+        self::userFunction(
+            'remove_filter',
+            array(
+                'args'   => is_int($priority)
+                    ? array($action, $callback, $priority)
+                    : array($action, $callback),
+                'times'  => 1,
+            )
+        );
+    }
 }

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -552,7 +552,7 @@ class WP_Mock
      *
      * @param string $action the action hook name
      * @param string|callable-string|callable|Type $callback the callable to be removed
-     * @param ?int|Type $priority the priority it should be registered at
+     * @param int|Type|null $priority the priority it should be registered at
      *
      * @return void
      * @throws InvalidArgumentException
@@ -573,7 +573,7 @@ class WP_Mock
      *
      * @param string $action the action hook name
      * @param null|string|callable-string|callable|Type $callback the callable to be removed
-     * @param ?int|Type $priority optional priority for the registered callback that is being removed
+     * @param int|Type|null $priority optional priority for the registered callback that is being removed
      *
      * @return void
      * @throws InvalidArgumentException
@@ -594,7 +594,7 @@ class WP_Mock
      *
      * @param string $filter the filter name
      * @param string|callable-string|callable|Type $callback the callable to be removed
-     * @param ?int|Type $priority the registered priority
+     * @param int|Type|null $priority the registered priority
      *
      * @return void
      * @throws InvalidArgumentException
@@ -615,7 +615,7 @@ class WP_Mock
      *
      * @param string $filter the filter name
      * @param null|string|callable-string|callable|Type $callback the callable to be removed
-     * @param ?int|Type $priority optional priority for the registered callback that is being removed
+     * @param int|Type|null $priority optional priority for the registered callback that is being removed
      *
      * @return void
      * @throws InvalidArgumentException

--- a/php/WP_Mock/Functions.php
+++ b/php/WP_Mock/Functions.php
@@ -92,7 +92,7 @@ class Functions
      *
      * @param string|callable-string $function function name
      * @param array<string, mixed> $args optional arguments
-     * @return Mockery\Expectation|Mockery\CompositeExpectation
+     * @return Mockery\Expectation
      * @throws InvalidArgumentException
      */
     public function register(string $function, array $args = [])
@@ -110,7 +110,7 @@ class Functions
         /** @var callable-string $method */
         $method = preg_replace('/\\\\+/', '_', $function);
 
-        /** @var Mockery\Expectation|Mockery\CompositeExpectation $expectation */
+        /** @var Mockery\Expectation $expectation */
         $expectation = $this->setUpMock($mock, $method, $args);
 
         Handler::registerHandler($function, [$mock, $method]);

--- a/php/WP_Mock/Functions.php
+++ b/php/WP_Mock/Functions.php
@@ -92,7 +92,7 @@ class Functions
      *
      * @param string|callable-string $function function name
      * @param array<string, mixed> $args optional arguments
-     * @return Mockery\Expectation
+     * @return Mockery\Expectation|Mockery\CompositeExpectation
      * @throws InvalidArgumentException
      */
     public function register(string $function, array $args = [])
@@ -110,7 +110,7 @@ class Functions
         /** @var callable-string $method */
         $method = preg_replace('/\\\\+/', '_', $function);
 
-        /** @var Mockery\Expectation $expectation */
+        /** @var Mockery\Expectation|Mockery\CompositeExpectation $expectation */
         $expectation = $this->setUpMock($mock, $method, $args);
 
         Handler::registerHandler($function, [$mock, $method]);

--- a/tests/Integration/WP_MockTest.php
+++ b/tests/Integration/WP_MockTest.php
@@ -349,11 +349,25 @@ class WP_MockTest extends WP_MockTestCase
         WP_Mock::expectActionRemoved('wpMockTestActionWithCallbackAndPriority', 'wpMockTestFunction', 10);
         WP_Mock::expectFilterRemoved('wpMockTestFilterWithCallbackAndPriority', 'wpMockTestFunction', 10);
 
+        WP_Mock::expectActionRemoved(
+            'wpMockTestActionWithCallbackAndAnyPriority',
+            'wpMockTestFunction',
+            \WP_Mock\Functions::type('int')
+        );
+        WP_Mock::expectFilterRemoved(
+            'wpMockTestFilterWithCallbackAndAnyPriority',
+            'wpMockTestFunction',
+            \WP_Mock\Functions::type('int')
+        );
+
         WP_Mock::expectActionRemoved('wpMockTestActionWithCallbackAndDefaultPriority', 'wpMockTestFunction');
         WP_Mock::expectFilterRemoved('wpMockTestFilterWithCallbackAndDefaultPriority', 'wpMockTestFunction');
 
         remove_action('wpMockTestActionWithCallbackAndPriority', 'wpMockTestFunction', 10);
         remove_filter('wpMockTestFilterWithCallbackAndPriority', 'wpMockTestFunction', 10);
+
+        remove_action('wpMockTestActionWithCallbackAndAnyPriority', 'wpMockTestFunction', rand(1,100));
+        remove_filter('wpMockTestFilterWithCallbackAndAnyPriority', 'wpMockTestFunction', rand(1,100));
 
         remove_action('wpMockTestActionWithCallbackAndDefaultPriority', 'wpMockTestFunction');
         remove_filter('wpMockTestFilterWithCallbackAndDefaultPriority', 'wpMockTestFunction');

--- a/tests/Integration/WP_MockTest.php
+++ b/tests/Integration/WP_MockTest.php
@@ -336,4 +336,29 @@ class WP_MockTest extends WP_MockTestCase
 
         $this->assertConditionsMet();
     }
+
+    /**
+     * @covers \WP_Mock::expectActionRemoved()
+     * @covers \WP_Mock::expectFilterRemoved()
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testCanExpectHooksRemoved() : void
+    {
+        WP_Mock::expectActionRemoved('wpMockTestActionWithCallbackAndPriority', 'wpMockTestFunction', 10);
+        WP_Mock::expectFilterRemoved('wpMockTestFilterWithCallbackAndPriority', 'wpMockTestFunction', 10);
+
+        WP_Mock::expectActionRemoved('wpMockTestActionWithCallbackAndDefaultPriority', 'wpMockTestFunction');
+        WP_Mock::expectFilterRemoved('wpMockTestFilterWithCallbackAndDefaultPriority', 'wpMockTestFunction');
+
+        remove_action('wpMockTestActionWithCallbackAndPriority', 'wpMockTestFunction', 10);
+        remove_filter('wpMockTestFilterWithCallbackAndPriority', 'wpMockTestFunction', 10);
+
+        remove_action('wpMockTestActionWithCallbackAndDefaultPriority', 'wpMockTestFunction');
+        remove_filter('wpMockTestFilterWithCallbackAndDefaultPriority', 'wpMockTestFunction');
+
+        $this->assertConditionsMet();
+    }
+    }
 }

--- a/tests/Integration/WP_MockTest.php
+++ b/tests/Integration/WP_MockTest.php
@@ -360,5 +360,22 @@ class WP_MockTest extends WP_MockTestCase
 
         $this->assertConditionsMet();
     }
+
+    /**
+     * @covers \WP_Mock::expectActionNotRemoved()
+     * @covers \WP_Mock::expectFilterNotRemoved()
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testCanExpectHooksNotRemoved() : void
+    {
+        WP_Mock::expectActionNotRemoved('wpMockTestActionWithCallbackAndPriority', 'wpMockTestFunction', 10);
+        WP_Mock::expectFilterNotRemoved('wpMockTestFilterWithCallbackAndPriority', 'wpMockTestFunction', 10);
+
+        WP_Mock::expectActionNotRemoved('wpMockTestActionWithCallbackAndDefaultPriority', 'wpMockTestFunction');
+        WP_Mock::expectFilterNotRemoved('wpMockTestFilterWithCallbackAndDefaultPriority', 'wpMockTestFunction');
+
+        $this->assertConditionsMet();
     }
 }


### PR DESCRIPTION
# Summary

As said in #157:

> WP_Mock provides useful helpers for `expectFilterAdded` and `expectFilterNotAdded`, and [their] companion actions. However, we have no canonical way of checking `remove_action` nor `remove_filter` calls.

See: [`remove_filter()`](https://github.com/WordPress/WordPress/blob/5b2ef0f91d4ee08703e755a42f3c2e96e36bdf0a/wp-includes/plugin.php#L313).

### Closes: #157

## Details

It's really just a convenience function on top of `WP_Mock::userFunction()`.

```php
public static function expectFilterRemoved(string $filter, $callback, $priority = null) : void
{
    self::userFunction(
        'remove_filter'
        array(
            'args'   => array_filter(func_get_args()),
            'times'  => 1,
        )
    );
}
```

We're using `array_filter()` there to handle the optional use of `$priority` in `remove_filter()`.

`::expectFilterNotRemoved()` is the same with `'times' => 0`.

## Contributor checklist 

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing


### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes