### PR TITLE
Add support for types in `expectFilter` mocks

### DIFF
--- a/docs/usage/mocking-wp-action-and-filter-hooks.md
+++ b/docs/usage/mocking-wp-action-and-filter-hooks.md
@@ -141,3 +141,50 @@ final class MyClassTest extends TestCase
     }
 }
 ```
+
+## Asserting that an object has been passed
+
+To assert that an object has been added as an argument, you can perform assertions referencing the object's class type.
+
+Take the code below, for example:
+
+```php
+namespace MyPlugin;
+
+class MyClass
+{
+    public function filterContent() : NewClass
+    {
+        return apply_filters('custom_content_filter', new NewClass());
+    }
+}
+
+class NewClass
+{
+    public function __construct()
+    {
+        echo 'New Class';
+    }
+}
+```
+
+We can do this:
+
+```php
+use WP_Mock;
+use WP_Mock\Tools\TestCase as TestCase;
+
+use MyPlugin\MyClass;
+use MyPlugin\NewClass;
+
+final class MyClassTest extends TestCase
+{
+    public function testAnonymousObject() : void 
+    {
+        WP_Mock::expectFilter('custom_content_filter', WP_Mock\Functions::type(NewClass::class));
+
+        $this->assertInstanceOf(NewClass::class, (new MyClass())->filterContent());
+        $this->assertConditionsMet();
+    }
+}
+```

--- a/php/WP_Mock/Functions.php
+++ b/php/WP_Mock/Functions.php
@@ -413,6 +413,9 @@ EOF;
      */
     public static function type(string $expected): Type
     {
-        return Mockery::type($expected);
+        $type = Mockery::type($expected);
+        Filter::$objects[ $expected ] = spl_object_hash($type);
+
+        return $type;
     }
 }

--- a/php/WP_Mock/Hook.php
+++ b/php/WP_Mock/Hook.php
@@ -22,6 +22,9 @@ abstract class Hook
     /** @var array<mixed> collection of processors */
     protected $processors = [];
 
+    /** @var array<mixed> collection of objects mapped to their Type hashes */
+    public static array $objects = [];
+
     /**
      * Hook constructor.
      *
@@ -62,6 +65,14 @@ abstract class Hook
         }
 
         if (is_object($value)){
+            if (! $value instanceof Type) {
+                $class = get_class($value);
+
+                if (isset(static::$objects[ $class ])) {
+                    return static::$objects[ $class ];
+                }
+            }
+
             return spl_object_hash($value);
         }
 

--- a/php/WP_Mock/Hook.php
+++ b/php/WP_Mock/Hook.php
@@ -68,8 +68,8 @@ abstract class Hook
             if (! $value instanceof Type) {
                 $class = get_class($value);
 
-                if (isset(static::$objects[ $class ])) {
-                    return static::$objects[ $class ];
+                if (isset(static::$objects[$class]) && is_string(static::$objects[$class])) {
+                    return static::$objects[$class];
                 }
             }
 

--- a/php/WP_Mock/Hook.php
+++ b/php/WP_Mock/Hook.php
@@ -22,7 +22,7 @@ abstract class Hook
     /** @var array<mixed> collection of processors */
     protected $processors = [];
 
-    /** @var array<mixed> collection of objects mapped to their Type hashes */
+    /** @var array<string> collection of objects mapped to their Type hashes */
     public static array $objects = [];
 
     /**

--- a/tests/Unit/WP_Mock/TestClass.php
+++ b/tests/Unit/WP_Mock/TestClass.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace WP_Mock\Tests\Unit\WP_Mock;
-
-class TestClass {
-    public function __construct() {
-        //Do nothing...
-    }
-}

--- a/tests/Unit/WP_Mock/TestClass.php
+++ b/tests/Unit/WP_Mock/TestClass.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace WP_Mock\Tests\Unit\WP_Mock;
+
+class TestClass {
+    public function __construct() {
+        //Do nothing...
+    }
+}

--- a/tests/Unit/WP_MockTest.php
+++ b/tests/Unit/WP_MockTest.php
@@ -9,6 +9,7 @@ use Generator;
 use PHPUnit\Framework\Exception;
 use Mockery\ExpectationInterface;
 use WP_Mock\Tests\WP_MockTestCase;
+use WP_Mock\Tests\Mocks\SampleClass;
 use WP_Mock\DeprecatedMethodListener;
 use WP_Mock\Tests\Unit\WP_Mock\TestClass;
 use Mockery\Exception\InvalidCountException;
@@ -235,9 +236,9 @@ class WP_MockTest extends WP_MockTestCase
     {
         WP_Mock::bootstrap();
 
-        WP_Mock::expectFilter('testFilter', WP_Mock\Functions::type(TestClass::class));
+        WP_Mock::expectFilter('testFilter', WP_Mock\Functions::type(SampleClass::class));
 
-        apply_filters('testFilter', new TestClass());
+        apply_filters('testFilter', new SampleClass());
 
         WP_Mock::assertFiltersCalled();
 

--- a/tests/Unit/WP_MockTest.php
+++ b/tests/Unit/WP_MockTest.php
@@ -2,17 +2,18 @@
 
 namespace WP_Mock\Tests\Unit;
 
-use Generator;
 use Mockery;
-use Mockery\Exception\InvalidCountException;
-use Mockery\ExpectationInterface;
+use WP_Mock;
+use stdClass;
+use Generator;
 use PHPUnit\Framework\Exception;
+use Mockery\ExpectationInterface;
+use WP_Mock\Tests\WP_MockTestCase;
+use WP_Mock\DeprecatedMethodListener;
+use WP_Mock\Tests\Unit\WP_Mock\TestClass;
+use Mockery\Exception\InvalidCountException;
 use PHPUnit\Framework\ExpectationFailedException;
 use SebastianBergmann\RecursionContext\InvalidArgumentException;
-use stdClass;
-use WP_Mock;
-use WP_Mock\DeprecatedMethodListener;
-use WP_Mock\Tests\WP_MockTestCase;
 
 /**
  * @covers \WP_Mock
@@ -218,6 +219,27 @@ class WP_MockTest extends WP_MockTestCase
         WP_Mock::expectFilter('testFilter2', 'testVal');
 
         $this->expectException(InvalidCountException::class);
+
+        Mockery::close();
+    }
+
+    /**
+     * @covers \WP_Mock::assertFiltersCalled()
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @return void
+     */
+    public function testAssertFiltersPassesWithTypes(): void
+    {
+        WP_Mock::bootstrap();
+
+        WP_Mock::expectFilter('testFilter', WP_Mock\Functions::type(TestClass::class));
+
+        apply_filters('testFilter', new TestClass());
+
+        WP_Mock::assertFiltersCalled();
 
         Mockery::close();
     }


### PR DESCRIPTION
<!--
Filling out the required portions of this template is mandatory. 
Any PR that does not include enough information to be reviewed may be closed at a maintainers' discretion.
All new code requires associated documentation and unit tests.
-->

# Summary <!-- Required -->

<!-- Please write a brief high level summary: this should be a summary of the changes which the pull request contains. -->

This PR introduces support for type inclusion in the `expectFilter` mock expressions. In this way it is possible to assert if an object has been passed in as an argument like so:

```php
\WP_Mock::expectFilter( 'my_filter', \WP_Mock\Functions::type( MyClass::class ) );
```

### Closes: #253 

## Details <!-- Optional -->

<!-- Please include a detailed explanation of the changes and/or the reasoning behind them. -->

At the moment, when we pass in an object or instance in our `apply_filters` and proceed to mock it using types, it incorrectly compares two different hashes, because our `\WP_Mock\Functions::type( MyClass::class )` returns a **Mockery Type** object whose hash is different from a `new MyClass()` object. See [here](https://github.com/10up/wp_mock/blob/010d556e0482e4d94776a5b0641429dca00333e4/php/WP_Mock/Filter.php#L32-L37).

```php
$key = $this->safe_offset($arg);
if (! is_array($processors) || ! isset($processors[ $key ])) {
    $this->strict_check();


    return $arg;
}
```

I have introduced the use of a static array in the **Hook** abstraction called `$objects` which basically acts as a hash map to store **key/value pairs** of the object's **class name** and the unique **hash value** of the Mockery Type associated with that object **when the WP_Mock\Functions::type()** is called in the `expectFilter`.

```php
/** @var array<mixed> collection of objects mapped to their Type hashes */
    public static array $objects = [];
```

**AND**

```php
{
    $type = Mockery::type($expected);
    Filter::$objects[ $expected ] = spl_object_hash($type);

    return $type;
}
```

In this way, I am able to cross-check if the key exists in the `is_object` call of the `safe_offset` method when an object or instance is passed in and then effectively return the correct hash for that object like so:

```php
if (is_object($value)){
    if (! $value instanceof Type) {
        $class = get_class($value);

        if (isset(static::$objects[ $class ])) {
            return static::$objects[ $class ];
        }
    }

    return spl_object_hash($value);
}
```

<img width="500" alt="unit-tests" src="https://github.com/user-attachments/assets/9a009abe-6450-4897-a005-37d30f59a89c" />

## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing <!-- Required -->

<!-- If applicable, add specific steps for the reviewer to perform as part of their testing process prior to approving this pull request. -->

Create classes called **MyClass** & **NewClass** like so:

```php
namespace MyPlugin;

class MyClass
{
    public function filterContent() : NewClass
    {
        return apply_filters('custom_content_filter', new NewClass());
    }
}

class NewClass
{
    public function __construct()
    {
        echo 'New Class';
    }
}
```

Create Test like so:

```php
use WP_Mock;
use WP_Mock\Tools\TestCase as TestCase;

use MyPlugin\MyClass;
use MyPlugin\NewClass;

final class MyClassTest extends TestCase
{
    public function testAnonymousObject() : void 
    {
        WP_Mock::expectFilter('custom_content_filter', WP_Mock\Functions::type(NewClass::class));

        $this->assertInstanceOf(NewClass::class, (new MyClass())->filterContent());
        $this->assertConditionsMet();
    }
}
```

Run test, it should pass successfully:

```bash
composer run test
```

<!-- List any configuration requirements for testing. -->

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes