### PR TITLE
Fix: GitHub workflows broken due to outdated versions / OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
       PHP_VERSION: ${{ matrix.php }}
 
     steps:
-      - uses: actions/checkout@7884fcad6b5d53d10323aee724dc68d8b9096a2e # v2.4.2
+      - uses: actions/checkout@v4
 
       - name: Set up PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@e6f75134d35752277f093989e72e140eaa222f35 # v2.28.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           coverage: pcov
@@ -37,7 +37,7 @@ jobs:
         id: composer-cache
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed # v2.1.7
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -48,7 +48,7 @@ jobs:
         run: composer install --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
 
       - name: Restore phpunit coverage cache
-        uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed # v2.1.7
+        uses: actions/cache@v4
         with:
           path: ${{ env.COVERAGE_CACHE_PATH }}
           key: ${{ runner.os }}-coverage-${{ github.ref }}-${{ github.sha }}
@@ -77,14 +77,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      - uses: actions/checkout@v4
 
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-      - uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -101,13 +101,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@e2f20e631ae6d7dd3b768f56a5d2af784dd54791 # v2.5.0
+      - uses: actions/checkout@v4
 
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@9b0c1fce7a93df8e3bb8926b0d6e9d89e92f20a7 # v3.0.11
+      - uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,17 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        php: [ '8.3', '8.2', '8.1' ]
-        os: [ 'ubuntu-latest' ]
         include:
+          - php: '8.3'
+            os: 'ubuntu-latest'
+          - php: '8.2'
+            os: 'ubuntu-latest'
+          - php: '8.1'
+            os: 'ubuntu-latest'
           - php: '8.0'
-            os: 'ubuntu-20.04'
+            os: 'ubuntu-24.04'
           - php: '7.4'
-            os: 'ubuntu-20.04'
+            os: 'ubuntu-24.04'
       fail-fast: false
     env:
       COVERAGE_CACHE_PATH: phpunit-coverage-cache

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,6 +3,7 @@ includes:
 parameters:
 	level: max
 	reportUnmatchedIgnoredErrors: false
+	treatPhpDocTypesAsCertain: false
 	exceptions:
 		check:
 			missingCheckedExceptionInThrows: true


### PR DESCRIPTION
# Summary <!-- Required -->

Updates the versions used for various actions to address:

> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: 937d24475381cd9c75ae6db12cb4e79714b926ed`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

Also removes deprecated usage of ubuntu-20.04  -- see https://github.com/actions/runner-images/issues/11101

Also updates the phpstan config to address an unrelated failure. See https://github.com/10up/wp_mock/pull/255/files#r1983301587

## Details <!-- Optional -->

<!-- Please include a detailed explanation of the changes and/or the reasoning behind them. -->

## Contributor checklist <!-- Required -->

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you are unsure about any of these, please ask for clarification. We are here to help! -->

- [ ] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly 
- [ ] I have added tests to cover changes introduced by this pull request
- [ ] All new and existing tests pass

## Testing <!-- Required -->

- [ ] Code review
- [ ] Checks pass / GH actions run successfully

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes