### PR TITLE
Add support for `withAnyArgs` method for `onFilter` calls.

### DIFF
--- a/docs/usage/mocking-wp-action-and-filter-hooks.md
+++ b/docs/usage/mocking-wp-action-and-filter-hooks.md
@@ -103,6 +103,28 @@ final class MyClassTest extends TestCase
 }
 ```
 
+We can also use the `withAnything` method to test that the filter is being applied. This is particulary useful in test cases where we do not care about the arguments but just its return value. This can be done like so:
+
+```php
+use MyPlugin\MyClass;
+use WP_Mock;
+use WP_Mock\Tools\TestCase as TestCase;
+
+final class MyClassTest extends TestCase
+{
+    public function testCanFilterContent() : void 
+    {
+        WP_Mock::onFilter('custom_content_filter')
+            ->withAnything()
+            ->reply('This is filtered');
+
+        $content = (new MyClass())->filterContent();
+
+        $this->assertEquals('This is filtered', $content);
+    }
+}
+```
+
 Alternatively, there is a method `WP_Mock::expectFilter()` that will add a bare assertion that the filter will be applied without changing the value:
 
 ```php

--- a/docs/usage/mocking-wp-action-and-filter-hooks.md
+++ b/docs/usage/mocking-wp-action-and-filter-hooks.md
@@ -103,7 +103,7 @@ final class MyClassTest extends TestCase
 }
 ```
 
-We can also use the `withAnything` method to test that the filter is being applied. This is particularly useful in test cases where we do not care about the arguments but just its return value. This can be done like so:
+We can also use the `withAnyArgs` method to test that the filter is being applied. This is particularly useful in test cases where we do not care about the arguments but just its return value. This can be done like so:
 
 ```php
 use MyPlugin\MyClass;
@@ -115,7 +115,7 @@ final class MyClassTest extends TestCase
     public function testCanFilterContent() : void 
     {
         WP_Mock::onFilter('custom_content_filter')
-            ->withAnything()
+            ->withAnyArgs()
             ->reply('This is filtered');
 
         $content = (new MyClass())->filterContent();

--- a/docs/usage/mocking-wp-action-and-filter-hooks.md
+++ b/docs/usage/mocking-wp-action-and-filter-hooks.md
@@ -103,7 +103,7 @@ final class MyClassTest extends TestCase
 }
 ```
 
-We can also use the `withAnything` method to test that the filter is being applied. This is particulary useful in test cases where we do not care about the arguments but just its return value. This can be done like so:
+We can also use the `withAnything` method to test that the filter is being applied. This is particularly useful in test cases where we do not care about the arguments but just its return value. This can be done like so:
 
 ```php
 use MyPlugin\MyClass;

--- a/php/WP_Mock/Filter.php
+++ b/php/WP_Mock/Filter.php
@@ -10,7 +10,7 @@ namespace WP_Mock;
 class Filter extends Hook
 {
     /** @var array<mixed> Collection of filter names mapped to random integers. */
-    public static array $filtersWithAnything = [];
+    protected static array $filtersWithAnything = [];
 
     /**
      * Apply the stored filter.

--- a/php/WP_Mock/Filter.php
+++ b/php/WP_Mock/Filter.php
@@ -49,6 +49,9 @@ class Filter extends Hook
         return call_user_func_array(array($processors, 'send'), $args);
     }
 
+    /**
+     * @return Filter_Responder
+     */
     protected function new_responder()
     {
         return new Filter_Responder();
@@ -63,7 +66,7 @@ class Filter extends Hook
     }
 
     /**
-     * @return Filter_Responder
+     * @return Action_Responder|Filter_Responder|HookedCallbackResponder
      */
     public function withAnything()
     {

--- a/php/WP_Mock/Filter.php
+++ b/php/WP_Mock/Filter.php
@@ -10,7 +10,7 @@ namespace WP_Mock;
 class Filter extends Hook
 {
     /** @var array<mixed> Collection of filter names mapped to random integers. */
-    protected static array $filtersWithAnything = [];
+    protected static array $filtersWithAnyArgs = [];
 
     /**
      * Apply the stored filter.
@@ -21,8 +21,8 @@ class Filter extends Hook
      */
     public function apply($args)
     {
-        if (isset(static::$filtersWithAnything[ $this->name ])) {
-            $args = array_values(static::$filtersWithAnything);
+        if (isset(static::$filtersWithAnyArgs[ $this->name ])) {
+            $args = array_values(static::$filtersWithAnyArgs);
         }
 
         if ($args[0] === null && count($args) === 1) {
@@ -68,10 +68,10 @@ class Filter extends Hook
     /**
      * @return Action_Responder|Filter_Responder|HookedCallbackResponder
      */
-    public function withAnything()
+    public function withAnyArgs()
     {
         $random_value = mt_rand();
-        static::$filtersWithAnything[ $this->name ] = $random_value;
+        static::$filtersWithAnyArgs[ $this->name ] = $random_value;
 
         return $this->with($random_value);
     }

--- a/php/WP_Mock/Filter.php
+++ b/php/WP_Mock/Filter.php
@@ -9,6 +9,9 @@ namespace WP_Mock;
  */
 class Filter extends Hook
 {
+    /** @var array<mixed> Collection of filter names mapped to random integers. */
+    public static array $filtersWithAnything = [];
+
     /**
      * Apply the stored filter.
      *
@@ -18,6 +21,10 @@ class Filter extends Hook
      */
     public function apply($args)
     {
+        if (isset(static::$filtersWithAnything[ $this->name ])) {
+            $args = array_values(static::$filtersWithAnything);
+        }
+
         if ($args[0] === null && count($args) === 1) {
             if (isset($this->processors['argsnull'])) {
                 return $this->processors['argsnull']->send();
@@ -53,6 +60,17 @@ class Filter extends Hook
     protected function get_strict_mode_message()
     {
         return sprintf('Unexpected use of apply_filters for filter %s', $this->name);
+    }
+
+    /**
+     * @return Filter_Responder
+     */
+    public function withAnything()
+    {
+        $random_value = mt_rand();
+        static::$filtersWithAnything[ $this->name ] = $random_value;
+
+        return $this->with($random_value);
     }
 }
 

--- a/tests/Unit/WP_MockTest.php
+++ b/tests/Unit/WP_MockTest.php
@@ -347,13 +347,13 @@ class WP_MockTest extends WP_MockTestCase
      * @return void
      * @throws Exception|InvalidArgumentException
      */
-    public function testOnFilterPassesWithAnything(): void
+    public function testOnFilterPassesWithAnyArgs(): void
     {
         WP_Mock::bootstrap();
 
         /** @phpstan-ignore-next-line */
         WP_Mock::onFilter('testFilter')
-            ->withAnything()
+            ->withAnyArgs()
             ->reply('Filtered value');
 
         $filtered_value = apply_filters('testFilter', 'Original value');

--- a/tests/Unit/WP_MockTest.php
+++ b/tests/Unit/WP_MockTest.php
@@ -312,4 +312,50 @@ class WP_MockTest extends WP_MockTestCase
 
         Mockery::close();
     }
+
+    /**
+     * @covers \WP_Mock::onFilter()
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @return void
+     */
+    public function testOnFilterPasses(): void
+    {
+        WP_Mock::bootstrap();
+
+        WP_Mock::onFilter('testFilter')
+            ->with('Original value')
+            ->reply('Filtered value');
+
+        $filtered_value = apply_filters('testFilter', 'Original value');
+
+        $this->assertSame('Filtered value', $filtered_value);
+
+        Mockery::close();
+    }
+
+    /**
+     * @covers \WP_Mock::onFilter()
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @return void
+     */
+    public function testOnFilterPassesWithAnything(): void
+    {
+        WP_Mock::bootstrap();
+
+        WP_Mock::onFilter('testFilter')
+            ->withAnything()
+            ->reply('Filtered value');
+
+        $filtered_value = apply_filters('testFilter', 'Original value');
+
+        $this->assertSame('Filtered value', $filtered_value);
+
+        Mockery::close();
+    }
 }

--- a/tests/Unit/WP_MockTest.php
+++ b/tests/Unit/WP_MockTest.php
@@ -320,11 +320,13 @@ class WP_MockTest extends WP_MockTestCase
      * @preserveGlobalState disabled
      *
      * @return void
+     * @throws Exception|InvalidArgumentException
      */
     public function testOnFilterPasses(): void
     {
         WP_Mock::bootstrap();
 
+        /** @phpstan-ignore-next-line */
         WP_Mock::onFilter('testFilter')
             ->with('Original value')
             ->reply('Filtered value');
@@ -343,11 +345,13 @@ class WP_MockTest extends WP_MockTestCase
      * @preserveGlobalState disabled
      *
      * @return void
+     * @throws Exception|InvalidArgumentException
      */
     public function testOnFilterPassesWithAnything(): void
     {
         WP_Mock::bootstrap();
 
+        /** @phpstan-ignore-next-line */
         WP_Mock::onFilter('testFilter')
             ->withAnything()
             ->reply('Filtered value');


### PR DESCRIPTION
# Summary <!-- Required -->

This PR implements a new method called `withAnyArgs` for `onFilter` calls. This method is particularly useful in test cases where we do not care about the filter arguments passed in but just its return value like so:

```php
WP_Mock::onFilter('custom_content_filter')
    ->withAnyArgs()
    ->reply('This is filtered')
```

### Closes: #156 

## Details <!-- Optional -->

I have introduced a static array called `$filtersWithAnyArgs` that basically acts as an associative array for filter names mapped to random integer values.

This array will help us store random integers at the point where the `withAnyArgs` method is called, so that we can check for those later in the `apply` method and accurately set our passed in args.

Run tests:

```php
vendor/bin/phpunit ./tests/Unit/WP_MockTest.php 
```

<img width="490" alt="Screenshot 2025-03-09 at 12 16 12" src="https://github.com/user-attachments/assets/ad15136e-b3a6-4d77-a70e-e83a5a7c90e1" />

## Contributor checklist <!-- Required -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing <!-- Required -->

Create class like so:

```php
namespace MyPlugin;

class MyClass
{
    public function filterContent() : string
    {
        return apply_filters('custom_content_filter', 'This is unfiltered');
    }
}
```

Create Test like so:

```php
use MyPlugin\MyClass;
use WP_Mock;
use WP_Mock\Tools\TestCase as TestCase;

final class MyClassTest extends TestCase
{
    public function testCanFilterContent() : void 
    {
        WP_Mock::onFilter('custom_content_filter')
            ->withAnyArgs()
            ->reply('This is filtered');

        $content = (new MyClass())->filterContent();

        $this->assertEquals('This is filtered', $content);
    }
}
```

Run test, it should pass successfully using the `withAnyArgs` method:

```bash
composer run test
```

<!-- List any configuration requirements for testing. -->

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [x] Code changes review
- [x] Documentation changes review
- [x] Unit tests pass
- [x] Static analysis passes