### PR TITLE
Fix: Multiple `onFilter` call issues related to the `withAnyArgs` method

### DIFF
--- a/php/WP_Mock/Filter.php
+++ b/php/WP_Mock/Filter.php
@@ -22,7 +22,7 @@ class Filter extends Hook
     public function apply($args)
     {
         if (isset(static::$filtersWithAnyArgs[ $this->name ])) {
-            $args = array_values(static::$filtersWithAnyArgs);
+            $args = [ static::$filtersWithAnyArgs[ $this->name ] ];
         }
 
         if ($args[0] === null && count($args) === 1) {

--- a/php/WP_Mock/Filter.php
+++ b/php/WP_Mock/Filter.php
@@ -22,7 +22,7 @@ class Filter extends Hook
     public function apply($args)
     {
         if (isset(static::$filtersWithAnyArgs[ $this->name ])) {
-            $args = [ static::$filtersWithAnyArgs[ $this->name ] ];
+            $args = static::$filtersWithAnyArgs[ $this->name ];
         }
 
         if ($args[0] === null && count($args) === 1) {

--- a/php/WP_Mock/Filter.php
+++ b/php/WP_Mock/Filter.php
@@ -71,7 +71,7 @@ class Filter extends Hook
     public function withAnyArgs()
     {
         $random_value = mt_rand();
-        static::$filtersWithAnyArgs[ $this->name ] = $random_value;
+        static::$filtersWithAnyArgs[ $this->name ] = [ $random_value ];
 
         return $this->with($random_value);
     }

--- a/php/WP_Mock/Filter.php
+++ b/php/WP_Mock/Filter.php
@@ -9,7 +9,7 @@ namespace WP_Mock;
  */
 class Filter extends Hook
 {
-    /** @var array<mixed> Collection of filter names mapped to random integers. */
+    /** @var array<string, array<int>> Collection of filter names mapped to random integers. */
     protected static array $filtersWithAnyArgs = [];
 
     /**

--- a/tests/Unit/WP_MockTest.php
+++ b/tests/Unit/WP_MockTest.php
@@ -363,6 +363,15 @@ class WP_MockTest extends WP_MockTestCase
         Mockery::close();
     }
 
+    /**
+     * @covers \WP_Mock::onFilter()
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @return void
+     * @throws Exception|InvalidArgumentException
+     */
     public function testMultipleOnFilterPassesWithAnyArgs(): void
     {
         WP_Mock::bootstrap();

--- a/tests/Unit/WP_MockTest.php
+++ b/tests/Unit/WP_MockTest.php
@@ -362,4 +362,34 @@ class WP_MockTest extends WP_MockTestCase
 
         Mockery::close();
     }
+
+    public function testMultipleOnFilterPassesWithAnyArgs(): void
+    {
+        WP_Mock::bootstrap();
+
+        /** @phpstan-ignore-next-line */
+        WP_Mock::onFilter('testFilter1')
+            ->withAnyArgs()
+            ->reply('Filtered value 1');
+
+        /** @phpstan-ignore-next-line */
+        WP_Mock::onFilter('testFilter2')
+            ->withAnyArgs()
+            ->reply('Filtered value 2');
+
+        /** @phpstan-ignore-next-line */
+        WP_Mock::onFilter('testFilter3')
+            ->withAnyArgs()
+            ->reply('Filtered value 3');
+
+        $filtered_value1 = apply_filters('testFilter1', 'Original value 1');
+        $filtered_value2 = apply_filters('testFilter2', 'Original value 2');
+        $filtered_value3 = apply_filters('testFilter3', 'Original value 3');
+
+        $this->assertSame('Filtered value 1', $filtered_value1);
+        $this->assertSame('Filtered value 2', $filtered_value2);
+        $this->assertSame('Filtered value 3', $filtered_value3);
+
+        Mockery::close();
+    }
 }


### PR DESCRIPTION
# Summary <!-- Required -->

This PR implements a fix for an issue I discovered when using multiple `onFilter` calls with the `withAnyArgs` method.

<img width="807" alt="Screenshot 2025-03-12 at 18 47 52" src="https://github.com/user-attachments/assets/3c1bb38a-830a-4a4a-907c-a61b7f0d8e11" />

### Closes: #258 

## Details <!-- Optional -->

While writing some unit test cases using the `withAnyArgs` method, I came across issues for multiple `onFilter` calls introduced into the tests. At the moment, if a single `onFilter` call is used alongside `withAnyArgs`, it works correctly, but for multiple cases, it doesn't correctly pass the tests. The expected behaviour should be that this works for both single and multiple use cases using the `withAnyArgs`.

This PR fixes this issue correctly.

<img width="587" alt="Screenshot 2025-03-12 at 19 42 19" src="https://github.com/user-attachments/assets/46cfd651-62a7-455b-9b58-257d38a78b84" />

---

Run tests:

```php
vendor/bin/phpunit ./tests/Unit/WP_MockTest.php 
```

## Contributor checklist <!-- Required -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing <!-- Required -->

```php
public function testMultipleOnFilterPassesWithAnyArgs(): void
{
    WP_Mock::bootstrap();

    /** @phpstan-ignore-next-line */
    WP_Mock::onFilter('testFilter1')
        ->withAnyArgs()
        ->reply('Filtered value 1');

    /** @phpstan-ignore-next-line */
    WP_Mock::onFilter('testFilter2')
        ->withAnyArgs()
        ->reply('Filtered value 2');

    /** @phpstan-ignore-next-line */
    WP_Mock::onFilter('testFilter3')
        ->withAnyArgs()
        ->reply('Filtered value 3');

    $filtered_value1 = apply_filters('testFilter1', 'Original value 1');
    $filtered_value2 = apply_filters('testFilter2', 'Original value 2');
    $filtered_value3 = apply_filters('testFilter3', 'Original value 3');

    $this->assertSame('Filtered value 1', $filtered_value1);
    $this->assertSame('Filtered value 2', $filtered_value2);
    $this->assertSame('Filtered value 3', $filtered_value3);

    Mockery::close();
}
```

Run test, it should pass successfully multiple times using the `withAnyArgs` method:

```bash
composer run test
```

<!-- List any configuration requirements for testing. -->

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [x] Code changes review
- [ ] Documentation changes review
- [x] Unit tests pass
- [x] Static analysis passes