### PR TITLE
Explicitly mark parameter as nullable to address PHP deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1](https://github.com/10up/wp_mock/compare/1.1.0...1.1.1) - 2025-12-03
+### Fixed
+- Address PHP deprecation warnings about implicitly nullable parameters
+
 ## [1.1.0](https://github.com/10up/wp_mock/compare/1.0.1...1.1.0) - 2025-03-11
 ### Added
 - Add support for types in `expectFilter()` mocks

--- a/php/WP_Mock/Tools/TestCase.php
+++ b/php/WP_Mock/Tools/TestCase.php
@@ -110,7 +110,7 @@ abstract class TestCase extends PhpUnitTestCase
      * @return TestResult
      * @throws Exception
      */
-    public function run(TestResult $result = null): TestResult
+    public function run(?TestResult $result = null): TestResult
     {
         if ($result === null) {
             $result = $this->createResult();


### PR DESCRIPTION
# Summary <!-- Required -->

This marks a parameter explicitly as being nullable, to address this deprecation warning:

```
PHP Deprecated:  WP_Mock\Tools\TestCase::run(): Implicitly marking parameter $result as nullable is deprecated, the explicit nullable type must be used instead in /vendor/10up/wp_mock/php/WP_Mock/Tools/TestCase.php on line 113
```

### Closes: #261

## Details <!-- Optional -->

<!-- Please include a detailed explanation of the changes and/or the reasoning behind them. -->

## Contributor checklist <!-- Required -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly (n/a)
- [ ] I have added tests to cover changes introduced by this pull request (n/a)
- [x] All new and existing tests pass

## Testing <!-- Required -->

<!-- If applicable, add specific steps for the reviewer to perform as part of their testing process prior to approving this pull request. -->

<!-- List any configuration requirements for testing. -->

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes