### PR TITLE
Add PHP 8.0 named parameters support

### DIFF
--- a/docs/usage/using-wp-mock.md
+++ b/docs/usage/using-wp-mock.md
@@ -74,6 +74,16 @@ For example, the invocation below will set the expectation that the `get_permali
 WP_Mock::userFunction('get_permalink')->once()->with(42)->andReturn('https://example.com/foo');
 ```
 
+To mock functions that are called using named parameters, e.g. `get_permalink(post: 42)`, you must pass the arguments as an associative array:
+
+```php
+WP_Mock::userFunction('get_permalink', [
+    'args' => [
+        'post' => '42',
+    ],
+])->once()->andReturn('https://example.com/foo');
+```
+
 ## Using expectations in arguments
 
 You can also pass an associative array of arguments to the second parameter of `WP_Mock::userFunction()` to set expectations about the function's arguments, the number of times it should be called, and what it should return.

--- a/php/WP_Mock/Functions.php
+++ b/php/WP_Mock/Functions.php
@@ -97,7 +97,8 @@ class Functions
      */
     public function register(string $function, array $args = [])
     {
-        $this->generateFunction($function);
+        $functionArgs = isset($args['args']) ? $args['args'] : [];
+        $this->generateFunction($function, $functionArgs);
 
         if (empty($this->mockedFunctions[$function])) {
             /** @phpstan-ignore-next-line */
@@ -138,7 +139,10 @@ class Functions
 
         // set the expected arguments the function should be called with
         if (isset($args['args'])) {
-            $this->setExpectedArgs($expectation, $args['args']);
+            $this->setExpectedArgs(
+                $expectation,
+                is_array($args['args']) ? array_values($args['args']): $args['args']
+            );
         }
 
         // set the expected return value based on a passed argument or return values for each call in order
@@ -272,25 +276,27 @@ class Functions
      * The declared function is namespace-aware.
      *
      * @param string $functionName function name
+     * @param string $functionArgs function arguments
      * @return void
      * @throws InvalidArgumentException
      */
-    protected function generateFunction(string $functionName): void
+    protected function generateFunction(string $functionName, array $functionArgs = []): void
     {
         $functionName = $this->sanitizeFunctionName($functionName);
 
         $this->validateFunctionName($functionName);
 
-        $this->createFunction($functionName) or $this->replaceFunction($functionName);
+        $this->createFunction($functionName, $functionArgs) or $this->replaceFunction($functionName);
     }
 
     /**
      * Creates a function using eval.
      *
      * @param string $functionName function name
+     * @param array $functionArgs function arguments, required only when calling mocked functions using named parameters
      * @return bool true if this function created the mock, false otherwise
      */
-    protected function createFunction(string $functionName): bool
+    protected function createFunction(string $functionName, array $functionArgs = []): bool
     {
         if (in_array($functionName, self::$userMockedFunctions, true)) {
             return true;
@@ -304,9 +310,19 @@ class Functions
         $name = array_pop($parts);
         $namespace = empty($parts) ? '' : 'namespace '.implode('\\', $parts).';'.PHP_EOL;
 
+        $functionNamedParameters = '';
+
+        $has_named_parameters = array_reduce( array_keys($functionArgs), function ($carry, $arg) {
+            return $carry && !is_int($arg);
+        }, true);
+
+        if($has_named_parameters){
+            $functionNamedParameters = implode(', ', array_map(fn($name) => '$' . $name, array_keys($functionArgs)));
+        }
+
         $declaration = <<<EOF
 $namespace
-function $name() {
+function $name($functionNamedParameters) {
 	return \\WP_Mock\\Functions\\Handler::handleFunction('$functionName', func_get_args());
 }
 EOF;

--- a/php/WP_Mock/Functions.php
+++ b/php/WP_Mock/Functions.php
@@ -276,7 +276,7 @@ class Functions
      * The declared function is namespace-aware.
      *
      * @param string $functionName function name
-     * @param string $functionArgs function arguments
+     * @param array<int|string, mixed> $functionArgs function arguments
      * @return void
      * @throws InvalidArgumentException
      */
@@ -293,7 +293,7 @@ class Functions
      * Creates a function using eval.
      *
      * @param string $functionName function name
-     * @param array $functionArgs function arguments, required only when calling mocked functions using named parameters
+     * @param array<int|string, mixed> $functionArgs function arguments, required only when calling mocked functions using named parameters
      * @return bool true if this function created the mock, false otherwise
      */
     protected function createFunction(string $functionName, array $functionArgs = []): bool

--- a/php/WP_Mock/Functions.php
+++ b/php/WP_Mock/Functions.php
@@ -97,7 +97,7 @@ class Functions
      */
     public function register(string $function, array $args = [])
     {
-        $functionArgs = isset($args['args']) ? $args['args'] : [];
+        $functionArgs = isset($args['args']) && is_array($args['args']) ? $args['args'] : [];
         $this->generateFunction($function, $functionArgs);
 
         if (empty($this->mockedFunctions[$function])) {

--- a/tests/Integration/WP_MockTest.php
+++ b/tests/Integration/WP_MockTest.php
@@ -358,7 +358,13 @@ class WP_MockTest extends WP_MockTestCase
             'return' => 'the-mocked-transient-value',
         ]);
 
+        // Without this, tests fail on PHP 7.4.
+        // PHP Fatal error:  Uncaught ParseError: syntax error, unexpected ':', expecting ')' in :362
+        $hidePhp8CodeFromOlderVersions = <<<'PHP'
+        return get_transient(transient: 'my-transient-name');
+        PHP;
+
         /** @phpstan-ignore-next-line function "exists" */
-        $this->assertEquals('the-mocked-transient-value', get_transient(transient: 'my-transient-name'));
+        $this->assertEquals('the-mocked-transient-value', eval($hidePhp8CodeFromOlderVersions));
     }
 }

--- a/tests/Integration/WP_MockTest.php
+++ b/tests/Integration/WP_MockTest.php
@@ -350,16 +350,13 @@ class WP_MockTest extends WP_MockTestCase
             $this->markTestSkipped('PHP 8.0 required for named parameters.');
         }
 
-        WP_Mock::userFunction(
-            'get_transient',
-            array(
-                'times'  => 1,
-                'args'   => array(
-                    'transient' => 'my-transient-name',
-                ),
-                'return' => 'the-mocked-transient-value',
-            )
-        );
+        WP_Mock::userFunction('get_transient', [
+            'times'  => 1,
+            'args'   => [
+                'transient' => 'my-transient-name',
+            ],
+            'return' => 'the-mocked-transient-value',
+        ]);
 
         /** @phpstan-ignore-next-line function "exists" */
         $this->assertEquals('the-mocked-transient-value', get_transient(transient: 'my-transient-name'));

--- a/tests/Integration/WP_MockTest.php
+++ b/tests/Integration/WP_MockTest.php
@@ -335,4 +335,33 @@ class WP_MockTest extends WP_MockTestCase
 
         $this->assertConditionsMet();
     }
+
+    /**
+     * Fix "Error : Unknown named parameter $transient" when passing named parameters in the argument list.
+     *
+     * @covers \WP_Mock::userFunction()
+     * @see WP_Mock\Functions::createFunction()
+     *
+     * @throws Exception
+     */
+    public function testCanMockNamedParameters(): void {
+
+        if(!version_compare(PHP_VERSION, '8.0', '>=')) {
+            $this->markTestSkipped('PHP 8.0 required for named parameters.');
+        }
+
+        WP_Mock::userFunction(
+            'get_transient',
+            array(
+                'times'  => 1,
+                'args'   => array(
+                    'transient' => 'my-transient-name',
+                ),
+                'return' => 'the-mocked-transient-value',
+            )
+        );
+
+        /** @phpstan-ignore-next-line function "exists" */
+        $this->assertEquals('the-mocked-transient-value', get_transient(transient: 'my-transient-name'));
+    }
 }


### PR DESCRIPTION
# Summary

Add support for using PHP 8.0 named parameters.

### Closes:

No issue opened.

## Details

Trying to call a mocked function like:

```php
$value = get_transient(
    transient: 'my-transient-name'
);
```

results in:

```
Error : Unknown named parameter $transient
```

This now works:

```php
WP_Mock::userFunction('get_transient', [
    'times'  => 1,
    'args'   => [
        'transient' => 'my-transient-name',
    ],
    'return' => 'the-mocked-transient-value',
]);
```

The changes use the `args` array's keys as the parameter names in the mocked function.

NB: this does not work:

```php
WP_Mock::userFunction('get_transient')->once()->with(['transient' => 'my-transient-name'])->andReturn('the-mocked-transient-value');
```

The `Functions::createFunction()` has already been called and the function skeleton built and `eval()`'d, which is where the parameter names must be added.

## Contributor checklist

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [x] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing

One test added which skips if the PHP version is too low.

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes