### PR TITLE
Add `::setStrictModeForTest()` function

### DIFF
--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -33,9 +33,9 @@ class WP_Mock
     protected static $__strict_mode = false;
 
     /**
-     * Check was strict mode set individually for this test.
+     * A record if strict mode was set individually for this test.
      *
-     * Using an associative array to hold test-method-string:is-enabled-bool.
+     * Uses an associative array containing both method and setting as test-method-string:is-enabled-bool.
      *
      * @used-by self::setStrictModeForTest()
      * @used-by self::isStrictModeForTest()

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -32,6 +32,19 @@ class WP_Mock
 
     protected static $__strict_mode = false;
 
+    /**
+     * Check was strict mode set individually for this test.
+     *
+     * Using an associative array to hold test-method-string:is-enabled-bool.
+     *
+     * @used-by self::setStrictModeForTest()
+     * @used-by self::isStrictModeForTest()
+     * @see self::strictMode()
+     *
+     * @var array<string, bool>
+     */
+    protected static $__strict_mode_for_individual_test = [];
+
     /** @var DeprecatedMethodListener */
     protected static $deprecatedMethodListener;
 
@@ -57,7 +70,7 @@ class WP_Mock
      */
     public static function strictMode()
     {
-        return (bool) self::$__strict_mode;
+        return self::isStrictModeForTest() ?? (bool) self::$__strict_mode;
     }
 
     /**
@@ -68,6 +81,72 @@ class WP_Mock
         if (! self::$__bootstrapped) {
             self::$__strict_mode = true;
         }
+    }
+
+    /**
+     * Sets strict mode on or off at runtime for an individual test.
+     *
+     * Records the config/preference for the individual test. Later this will be preferred over the default.
+     *
+     * @param bool $enabled
+     * @throws Exception when the test case name cannot be determined.
+     */
+    public static function setStrictModeForTest(bool $enabled = true): void
+    {
+        $currentTestName = self::getCurrentlyRunningTestName();
+        if(is_null($currentTestName)){
+            throw new Exception('Failed to determine current test name');
+        }
+        self::$__strict_mode_for_individual_test = [$currentTestName => $enabled,];
+    }
+
+    /**
+     * Check was strict mode configured individually for this test case.
+     *
+     * @see self::setStrictModeForTest()
+     * @see self::$__strict_mode_for_individual_test
+     *
+     * @return ?bool `null` when not set, boolean preference when set.
+     */
+    protected static function isStrictModeForTest(): ?bool {
+        if( empty( self::$__strict_mode_for_individual_test ) ) {
+            return null;
+        }
+
+        $currentTestName = self::getCurrentlyRunningTestName();
+
+        if(!is_null($currentTestName) && isset(self::$__strict_mode_for_individual_test[$currentTestName])) {
+            return self::$__strict_mode_for_individual_test[$currentTestName];
+        }
+        
+        // Reset the array since it is only relevant for the current test case run.
+        self::$__strict_mode_for_individual_test = [];
+
+        return null;
+    }
+
+    /**
+     * Perform a backtrace to determine the currently running test.
+     *
+     * @return ?string of `class-string::method`
+     */
+    protected static function getCurrentlyRunningTestName(): ?string {
+        $backtrace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+
+        /** @var array{class?:string, function?:string} $trace */
+        foreach ($backtrace as $trace) {
+            if (isset($trace['class']) && isset($trace['function'])) {
+                // Check if this is a PHPUnit test class
+                if (is_subclass_of($trace['class'], \PHPUnit\Framework\TestCase::class)) {
+                    // Test method names start with 'test' or have @test annotation
+                    if (strpos($trace['function'], 'test') === 0) {
+                        return $trace['class'] . '::' . $trace['function'];
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Integration/WP_MockTest.php
+++ b/tests/Integration/WP_MockTest.php
@@ -44,6 +44,11 @@ class WP_MockTest extends WP_MockTestCase
      */
     protected function setUp(): void
     {
+        // Reset to default strict-mode after tests that manipulate this value.
+        $property = new \ReflectionProperty( \WP_Mock::class, '__strict_mode' );
+        $property->setAccessible( true );
+        $property->setValue( null, false );
+
         if (! $this->isInIsolation()) {
             WP_Mock::setUp();
         }

--- a/tests/Integration/WP_MockTest.php
+++ b/tests/Integration/WP_MockTest.php
@@ -44,16 +44,21 @@ class WP_MockTest extends WP_MockTestCase
      */
     protected function setUp(): void
     {
-        // Reset to default strict-mode after tests that manipulate this value.
-        $property = new \ReflectionProperty( \WP_Mock::class, '__strict_mode' );
-        $property->setAccessible( true );
-        $property->setValue( null, false );
-
         if (! $this->isInIsolation()) {
             WP_Mock::setUp();
         }
 
         require_once(dirname(__DIR__).'/Mocks/Functions.php');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        // Reset to default strict-mode after tests that manipulate this value.
+        $property = new \ReflectionProperty( \WP_Mock::class, '__strict_mode' );
+        $property->setAccessible( true );
+        $property->setValue( null, false );
     }
 
     /**

--- a/tests/Integration/WP_MockTest.php
+++ b/tests/Integration/WP_MockTest.php
@@ -44,24 +44,23 @@ class WP_MockTest extends WP_MockTestCase
      */
     protected function setUp(): void
     {
-        if (! $this->isInIsolation()) {
-            WP_Mock::setUp();
-        }
-
-        require_once(dirname(__DIR__).'/Mocks/Functions.php');
-    }
-
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-
-        // Reset to default strict-mode after tests that manipulate this value.
+        /**
+         * Reset to default strict-mode after tests that manipulate this value.
+         *
+         * @see WP_Mock::$__strict_mode
+         */
         $property = new \ReflectionProperty( \WP_Mock::class, '__strict_mode' );
         // "Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect".
         if(!version_compare(PHP_VERSION, '8.5', '>=')) {
             $property->setAccessible( true );
         }
         $property->setValue( null, false );
+
+        if (! $this->isInIsolation()) {
+            WP_Mock::setUp();
+        }
+
+        require_once(dirname(__DIR__).'/Mocks/Functions.php');
     }
 
     /**

--- a/tests/Integration/WP_MockTest.php
+++ b/tests/Integration/WP_MockTest.php
@@ -335,4 +335,59 @@ class WP_MockTest extends WP_MockTestCase
 
         $this->assertConditionsMet();
     }
+
+    /**
+     * @covers \WP_Mock::setStrictModeForTest()
+     *
+     * @return void
+     * @throws Exception
+     */
+    public function testCanDisableStrictModeForLegacyCode() : void
+    {
+        // Set default ala `WP_Mock::activateStrictMode()`.
+        $property = new \ReflectionProperty( WP_Mock::class, '__strict_mode' );
+        $property->setAccessible( true );
+        $property->setValue( null, true );
+
+        // Temporarily disable strict mode to test legacy code
+        WP_Mock::setStrictModeForTest(false);
+
+        // This would normally fail in strict mode, but should pass now
+        add_action('legacy_action', 'legacy_callback');
+
+        $this->assertTrue(true);
+    }
+
+    /**
+     * @covers \WP_Mock::setStrictModeForTest()
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @return void
+     * @throws Exception|ExpectationFailedException
+     */
+    public function testCanEnableStrictModeForSpecificTest() : void
+    {
+        /**
+         * Set default ala `WP_Mock::activateStrictMode()`, `false`.
+         * @see \WP_Mock::$__strict_mode
+         */
+        $property = new \ReflectionProperty( \WP_Mock::class, '__strict_mode' );
+        $property->setAccessible( true );
+        $property->setValue( null, false );
+
+        $this->assertFalse(WP_Mock::strictMode());
+
+        // Enable strict mode for this specific test
+        WP_Mock::setStrictModeForTest();
+        $this->assertTrue(WP_Mock::strictMode());
+
+        // This should throw an exception because we haven't set expectations
+        $this->expectException(ExpectationFailedException::class);
+        $this->expectExceptionMessage('No handler found for function unmocked_function');
+
+        // Call an unmocked function
+        WP_Mock\Functions\Handler::handleFunction('unmocked_function');
+    }
 }

--- a/tests/Integration/WP_MockTest.php
+++ b/tests/Integration/WP_MockTest.php
@@ -57,7 +57,10 @@ class WP_MockTest extends WP_MockTestCase
 
         // Reset to default strict-mode after tests that manipulate this value.
         $property = new \ReflectionProperty( \WP_Mock::class, '__strict_mode' );
-        $property->setAccessible( true );
+        // "Method ReflectionProperty::setAccessible() is deprecated since 8.5, as it has no effect".
+        if(!version_compare(PHP_VERSION, '8.5', '>=')) {
+            $property->setAccessible( true );
+        }
         $property->setValue( null, false );
     }
 
@@ -356,7 +359,9 @@ class WP_MockTest extends WP_MockTestCase
     {
         // Set default ala `WP_Mock::activateStrictMode()`.
         $property = new \ReflectionProperty( WP_Mock::class, '__strict_mode' );
-        $property->setAccessible( true );
+        if(!version_compare(PHP_VERSION, '8.5', '>=')) {
+            $property->setAccessible( true );
+        }
         $property->setValue( null, true );
 
         // Temporarily disable strict mode to test legacy code
@@ -384,7 +389,9 @@ class WP_MockTest extends WP_MockTestCase
          * @see \WP_Mock::$__strict_mode
          */
         $property = new \ReflectionProperty( \WP_Mock::class, '__strict_mode' );
-        $property->setAccessible( true );
+        if(!version_compare(PHP_VERSION, '8.5', '>=')) {
+            $property->setAccessible( true );
+        }
         $property->setValue( null, false );
 
         $this->assertFalse(WP_Mock::strictMode());

--- a/tests/Unit/WP_MockTest.php
+++ b/tests/Unit/WP_MockTest.php
@@ -69,6 +69,66 @@ class WP_MockTest extends WP_MockTestCase
     }
 
     /**
+     * @covers \WP_Mock::setStrictModeForTest()
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testSetStrictModeForTestCanDisableStrictMode(): void
+    {
+        // Set default ala `WP_Mock::activateStrictMode()`.
+        $property = new \ReflectionProperty( WP_Mock::class, '__strict_mode' );
+        $property->setAccessible( true );
+        $property->setValue( null, true );
+
+
+        WP_Mock::setStrictModeForTest(false);
+
+        $this->assertFalse(WP_Mock::strictMode());
+    }
+
+    /**
+     * @covers \WP_Mock::setStrictModeForTest()
+     *
+     * @return void
+     * @throws \Exception
+     */
+    public function testSetStrictModeForTestCanEnableStrictMode(): void
+    {
+        // Set default ala `WP_Mock::activateStrictMode()`, but `false`.
+        $property = new \ReflectionProperty( WP_Mock::class, '__strict_mode' );
+        $property->setAccessible( true );
+        $property->setValue( null, false );
+
+        WP_Mock::setStrictModeForTest();
+
+        $this->assertTrue(WP_Mock::strictMode());
+    }
+
+    /**
+     * @covers \WP_Mock::setStrictModeForTest()
+     *
+     * @return void
+     * @throws ExpectationFailedException|InvalidArgumentException
+     */
+    public function testPreviousSetStrictModeForTestIsNotRelevant(): void
+    {
+        // Set default ala `WP_Mock::activateStrictMode()`.
+        $property = new \ReflectionProperty( WP_Mock::class, '__strict_mode' );
+        $property->setAccessible( true );
+        $property->setValue( null, true );
+
+        // Set individual test configuration for another tests.
+        $property = new \ReflectionProperty( WP_Mock::class, '__strict_mode_for_individual_test' );
+        $property->setAccessible( true );
+        $property->setValue( null, [
+            'WP_Mock\Tests\Unit\WP_MockTest::testSetStrictModeForTestCanDisableStrictMode' => false
+        ]);
+
+        $this->assertTrue(WP_Mock::strictMode());
+    }
+
+    /**
      * @covers \WP_Mock::userFunction()
      *
      * @runInSeparateProcess


### PR DESCRIPTION
# Summary 

Adds `WP_Mock::setStrictModeForTest()` to control strict mode for an individual test, respecting the bootstrapped configuration for other tests.

### Closes: 

#249 

## Details

Adds `setStrictModeForTest($enabled = true)`. This runs a backtrace to determine the currently running test, records the test name and preference as an associative array in `WP_Mock::$__strict_mode_for_individual_test`, then `WP_Mock::strictMode()` has been updated to check a new function `::isStrictModeForTest()` which again determines the running test and if it has been set, uses the set value in preference to the default (bootstrapped) value.

NB: If tests are written using `@test` annotations or `#[Test]` attribute, they will not be recognised as tests.

An easier possibility would be to use `WP_Mock\Tools\TestCase` and use its set-up/tear-down methods, but that's not how I generally use this tool myself.

Once I get feedback and think a bit more about this, I'll add the appropriate documentation.

## Contributor checklist <!-- Required -->

- [x] I agree to follow this project's [**Code of Conduct**](https://github.com/10up/.github/blob/trunk/CODE_OF_CONDUCT.md).
- [ ] I have updated the documentation accordingly 
- [x] I have added tests to cover changes introduced by this pull request
- [x] All new and existing tests pass

## Testing 

Tests added, phpcs passing, phpstan passing.

### Reviewer checklist <!-- Required -->

<!-- The following checklist is for the reviewer: add any steps that may be relevant while reviewing this pull request --> 

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes