### PR TITLE
fix(hook): use stable Type string key in safe_offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Allow multiple `expectActionAdded` / `expectFilterAdded` expectations using `Functions::type()` with the same method name ([#268](https://github.com/10up/wp_mock/issues/268))
+
 ## [1.1.1](https://github.com/10up/wp_mock/compare/1.1.0...1.1.1) - 2025-12-03
 ### Fixed
 - Address PHP deprecation warnings about implicitly nullable parameters

--- a/docs/usage/mocking-wp-action-and-filter-hooks.md
+++ b/docs/usage/mocking-wp-action-and-filter-hooks.md
@@ -34,6 +34,16 @@ If the actual instance of an expected class cannot be passed, `AnyInstance` can 
 WP_Mock::expectFilterAdded('the_content', [new \WP_Mock\Matcher\AnyInstance(Special::class), 'the_content']);
 ```
 
+You can also match object method callbacks by class type with `Functions::type()`. This is useful when multiple classes register the same method name on the same hook:
+
+```php
+WP_Mock::expectActionAdded('init', [WP_Mock\Functions::type(SampleClass::class), 'action']);
+WP_Mock::expectActionAdded('init', [WP_Mock\Functions::type(SampleSubClass::class), 'action']);
+
+add_action('init', [new SampleClass(), 'action']);
+add_action('init', [new SampleSubClass(), 'action']);
+```
+
 ## Asserting that closures have been added as hook callbacks
 
 Sometimes it's handy to add a [Closure](https://secure.php.net/manual/en/class.closure.php) as a WordPress hook instead of defining a function in the global namespace. To assert that such a hook has been added, you can perform assertions referencing the Closure class or a `callable` type:

--- a/php/WP_Mock.php
+++ b/php/WP_Mock.php
@@ -130,6 +130,7 @@ class WP_Mock
     {
         self::$event_manager->flush();
         self::$functionsManager->flush();
+        \WP_Mock\Hook::$objects = [];
 
         Mockery::close();
         Handler::cleanup();
@@ -288,7 +289,7 @@ class WP_Mock
      * Adds an expectation that an action hook should be added.
      *
      * @param string $action the action hook name
-     * @param string|callable-string|callable|Type $callback the callback that should be registered
+     * @param string|callable-string|callable|Type|array{0: mixed, 1: string} $callback the callback that should be registered
      * @param int $priority the priority it should be registered at
      * @param int $args the number of arguments that should be allowed
      * @return void
@@ -302,7 +303,7 @@ class WP_Mock
      * Adds an expectation that an action hook should not be added.
      *
      * @param string $action the action hook name
-     * @param string|callable-string|callable|Type $callback the callback that should be registered
+     * @param string|callable-string|callable|Type|array{0: mixed, 1: string} $callback the callback that should be registered
      * @param int $priority the priority it should be registered at
      * @param int $args the number of arguments that should be allowed
      * @return void
@@ -316,7 +317,7 @@ class WP_Mock
      * Add an expectation that a filter hook should be added.
      *
      * @param string $filter the filter hook name
-     * @param string|callable-string|callable|Type $callback the callback that should be registered
+     * @param string|callable-string|callable|Type|array{0: mixed, 1: string} $callback the callback that should be registered
      * @param int $priority the priority it should be registered at
      * @param int $args the number of arguments that should be allowed
      * @return void
@@ -330,7 +331,7 @@ class WP_Mock
      * Adds an expectation that a filter hook should not be added.
      *
      * @param string $filter the filter hook name
-     * @param string|callable-string|callable|Type $callback the callback that should be registered
+     * @param string|callable-string|callable|Type|array{0: mixed, 1: string} $callback the callback that should be registered
      * @param int $priority the priority it should be registered at
      * @param int $args the number of arguments that should be allowed
      * @return void
@@ -347,7 +348,7 @@ class WP_Mock
      *
      * @param string $type the type of hook being added ('action' or 'filter')
      * @param string $hook the hook name
-     * @param string|callable-string|callable|Type $callback the callback that should be registered
+     * @param string|callable-string|callable|Type|array{0: mixed, 1: string} $callback the callback that should be registered
      * @param int $priority the priority it should be registered at
      * @param int $args the number of arguments that should be allowed
      * @return void
@@ -370,7 +371,7 @@ class WP_Mock
      *
      * @param string $type the type of hook being added ('action' or 'filter')
      * @param string $hook the hook name
-     * @param string|callable-string|callable|Type $callback the callback that should be registered
+     * @param string|callable-string|callable|Type|array{0: mixed, 1: string} $callback the callback that should be registered
      * @param int $priority the priority it should be registered at
      * @param int $args the number of arguments that should be allowed
      * @return void

--- a/php/WP_Mock/Functions.php
+++ b/php/WP_Mock/Functions.php
@@ -414,7 +414,9 @@ EOF;
     public static function type(string $expected): Type
     {
         $type = Mockery::type($expected);
-        Filter::$objects[ $expected ] = spl_object_hash($type);
+        // Stable key (not spl_object_hash): Type is discarded after expect* registration,
+        // so GC can recycle the hash and collide when the same method is expected twice.
+        Filter::$objects[ $expected ] = (string) $type;
 
         return $type;
     }

--- a/php/WP_Mock/Hook.php
+++ b/php/WP_Mock/Hook.php
@@ -64,13 +64,17 @@ abstract class Hook
             return (string) $value;
         }
 
-        if (is_object($value)){
-            if (! $value instanceof Type) {
-                $class = get_class($value);
+        if (is_object($value)) {
+            // Type matchers use a stable string key so multiple Functions::type() expectations
+            // do not collide when PHP reuses spl_object_hash after GC.
+            if ($value instanceof Type) {
+                return (string) $value;
+            }
 
-                if (isset(static::$objects[$class]) && is_string(static::$objects[$class])) {
-                    return static::$objects[$class];
-                }
+            $class = get_class($value);
+
+            if (isset(static::$objects[$class]) && is_string(static::$objects[$class])) {
+                return static::$objects[$class];
             }
 
             return spl_object_hash($value);

--- a/tests/Mocks/SampleSubClass.php
+++ b/tests/Mocks/SampleSubClass.php
@@ -7,4 +7,8 @@ class SampleSubClass extends SampleClass
     public function action(): void
     {
     }
+
+    public function action2(): void
+    {
+    }
 }

--- a/tests/Unit/WP_Mock/HookTest.php
+++ b/tests/Unit/WP_Mock/HookTest.php
@@ -9,7 +9,10 @@ use Mockery;
 use PHPUnit\Framework\TestCase;
 use ReflectionException;
 use stdClass;
+use WP_Mock\Functions;
 use WP_Mock\Hook;
+use WP_Mock\Tests\Mocks\SampleClass;
+use WP_Mock\Tests\Mocks\SampleSubClass;
 use WP_Mock\Traits\AccessInaccessibleClassMembersTrait;
 
 /**
@@ -63,5 +66,44 @@ final class HookTest extends TestCase
         yield 'scalar (false)' => [false, ''];
         yield 'object' => [$objectInstance, spl_object_hash($objectInstance)];
         yield 'array (callback)' => [[$callbackInstance, 'callback'], spl_object_hash($callbackInstance).'callback'];
+        yield 'type matcher (class)' => [Mockery::type(SampleClass::class), (string) Mockery::type(SampleClass::class)];
+    }
+
+    /**
+     * @covers \WP_Mock\Hook::safe_offset()
+     * @covers \WP_Mock\Functions::type()
+     *
+     * @return void
+     * @throws ReflectionException|Exception
+     */
+    public function testTypeSafeOffsetIsStableAcrossMultipleTypeCalls(): void
+    {
+        Hook::$objects = [];
+
+        $instance = $this->getMockForAbstractClass(Hook::class, [], '', false);
+        $method = $this->getInaccessibleMethod($instance, 'safe_offset');
+
+        $typeKey1 = $method->invokeArgs($instance, [Functions::type(SampleClass::class)]);
+        unset($typeKey1);
+        gc_collect_cycles();
+
+        $typeSampleClass = Functions::type(SampleClass::class);
+        $typeSampleSubClass = Functions::type(SampleSubClass::class);
+
+        $keyClass = $method->invokeArgs($instance, [$typeSampleClass]);
+        $keySubClass = $method->invokeArgs($instance, [$typeSampleSubClass]);
+        $keyInstance = $method->invokeArgs($instance, [new SampleClass()]);
+        $keySubInstance = $method->invokeArgs($instance, [new SampleSubClass()]);
+        $keyCallbackClass = $method->invokeArgs($instance, [[$typeSampleClass, 'action']]);
+        $keyCallbackSubClass = $method->invokeArgs($instance, [[$typeSampleSubClass, 'action']]);
+
+        $this->assertNotSame($keyClass, $keySubClass);
+        $this->assertSame($keyClass, $keyInstance);
+        $this->assertSame($keySubClass, $keySubInstance);
+        $this->assertNotSame($keyCallbackClass, $keyCallbackSubClass);
+        $this->assertSame((string) $typeSampleClass, $keyClass);
+        $this->assertSame((string) $typeSampleSubClass, $keySubClass);
+
+        Hook::$objects = [];
     }
 }

--- a/tests/Unit/WP_MockTest.php
+++ b/tests/Unit/WP_MockTest.php
@@ -10,6 +10,8 @@ use PHPUnit\Framework\Exception;
 use Mockery\ExpectationInterface;
 use WP_Mock\Tests\WP_MockTestCase;
 use WP_Mock\Tests\Mocks\SampleClass;
+use WP_Mock\Tests\Mocks\SampleSubClass;
+use WP_Mock\Matcher\AnyInstance;
 use WP_Mock\DeprecatedMethodListener;
 use WP_Mock\Tests\Unit\WP_Mock\TestClass;
 use Mockery\Exception\InvalidCountException;
@@ -400,5 +402,135 @@ class WP_MockTest extends WP_MockTestCase
         $this->assertSame('Filtered value 3', $filtered_value3);
 
         Mockery::close();
+    }
+
+    /**
+     * @covers \WP_Mock::expectActionAdded()
+     * @covers \WP_Mock::expectHookAdded()
+     * @covers \WP_Mock\Functions::type()
+     * @covers \WP_Mock\Hook::safe_offset()
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @return void
+     * @throws ExpectationFailedException|Exception|\Exception
+     */
+    public function testMultipleActionsTypeSameMethod(): void
+    {
+        WP_Mock::activateStrictMode();
+        WP_Mock::bootstrap();
+
+        WP_Mock::expectActionAdded(
+            'init',
+            array(WP_Mock\Functions::type(SampleClass::class), 'action')
+        );
+
+        WP_Mock::expectActionAdded(
+            'init',
+            array(WP_Mock\Functions::type(SampleSubClass::class), 'action')
+        );
+
+        add_action('init', array(new SampleClass(), 'action'));
+        add_action('init', array(new SampleSubClass(), 'action'));
+
+        $this->assertConditionsMet();
+    }
+
+    /**
+     * @covers \WP_Mock::expectActionAdded()
+     * @covers \WP_Mock::expectHookAdded()
+     * @covers \WP_Mock\Functions::type()
+     * @covers \WP_Mock\Hook::safe_offset()
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @return void
+     * @throws ExpectationFailedException|Exception|\Exception
+     */
+    public function testMultipleActionsTypeDistinctMethod(): void
+    {
+        WP_Mock::activateStrictMode();
+        WP_Mock::bootstrap();
+
+        WP_Mock::expectActionAdded(
+            'init',
+            array(WP_Mock\Functions::type(SampleClass::class), 'action')
+        );
+
+        WP_Mock::expectActionAdded(
+            'init',
+            array(WP_Mock\Functions::type(SampleSubClass::class), 'action2')
+        );
+
+        add_action('init', array(new SampleClass(), 'action'));
+        add_action('init', array(new SampleSubClass(), 'action2'));
+
+        $this->assertConditionsMet();
+    }
+
+    /**
+     * @covers \WP_Mock::expectActionAdded()
+     * @covers \WP_Mock::expectHookAdded()
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @return void
+     * @throws ExpectationFailedException|Exception|\Exception
+     */
+    public function testMultipleActionsAnyInstanceSameMethod(): void
+    {
+        WP_Mock::activateStrictMode();
+        WP_Mock::bootstrap();
+
+        WP_Mock::expectActionAdded(
+            'init',
+            array(new AnyInstance(SampleClass::class), 'action')
+        );
+
+        WP_Mock::expectActionAdded(
+            'init',
+            array(new AnyInstance(SampleSubClass::class), 'action')
+        );
+
+        add_action('init', array(new SampleClass(), 'action'));
+        add_action('init', array(new SampleSubClass(), 'action'));
+
+        $this->assertConditionsMet();
+    }
+
+    /**
+     * @covers \WP_Mock::expectFilterAdded()
+     * @covers \WP_Mock::expectHookAdded()
+     * @covers \WP_Mock\Functions::type()
+     * @covers \WP_Mock\Hook::safe_offset()
+     *
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     *
+     * @return void
+     * @throws ExpectationFailedException|Exception|\Exception
+     */
+    public function testMultipleFiltersTypeSameMethod(): void
+    {
+        WP_Mock::activateStrictMode();
+        WP_Mock::bootstrap();
+
+        WP_Mock::expectFilterAdded(
+            'the_content',
+            array(WP_Mock\Functions::type(SampleClass::class), 'action')
+        );
+
+        WP_Mock::expectFilterAdded(
+            'the_content',
+            array(WP_Mock\Functions::type(SampleSubClass::class), 'action')
+        );
+
+        add_filter('the_content', array(new SampleClass(), 'action'));
+        add_filter('the_content', array(new SampleSubClass(), 'action'));
+
+        $this->assertConditionsMet();
     }
 }


### PR DESCRIPTION
### Closes: #268

## Summary

`WP_Mock::expectActionAdded` (and the same path through `expectFilterAdded` and `expectHookAdded`) failed under strict mode when the test registered two class-typed callbacks that shared a method name, for example:

```php
WP_Mock::expectActionAdded('init', [WP_Mock\Functions::type(SampleClass::class), 'action']);
WP_Mock::expectActionAdded('init', [WP_Mock\Functions::type(SampleSubClass::class), 'action']);
```

The second expectation silently overwrote the first, producing a Mockery failure: `Method intercepted(<Any Arguments>) should be called at least 1 times but called 0 times`. Distinct method names worked by accident, and `AnyInstance` was unaffected.

## Details

`Functions::type()` was storing `spl_object_hash($type)` as the key in `Hook::$objects`. The Type object itself was not retained after `expect*` returned, so PHP could reclaim it. The next `Mockery::type()` call reused the same object handle, producing the same hash. In `Hook::safe_offset()` the processor key for an `[Type, method]` array is the hash concatenated with the method name, so two different classes paired with the same method name collapsed to the same key.

The fix uses Mockery's `Type::__toString()` output (for example `<MyClass>`) as the stable key in both `Functions::type()` and the `Type` branch of `Hook::safe_offset()`. `WP_Mock::tearDown()` now clears `Hook::$objects` so the mapping does not leak across tests.

Real-instance resolution still routes through `Hook::$objects[get_class($instance)]`, so an actual `new SampleClass()` continues to match the stable string written by `Functions::type(SampleClass::class)`. Closure and `callable` Type handling is unchanged.

Introduced by #254 (1.1.0).

## Contributor checklist

- [x] I agree to follow this project's Code of Conduct.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover changes introduced by this pull request.
- [x] All new and existing tests pass.

## Testing

The reporter's reproduction and adjacent cases are added as unit tests:

- `tests/Unit/WP_MockTest.php::testMultipleActionsTypeSameMethod` (the failing case)
- `tests/Unit/WP_MockTest.php::testMultipleActionsTypeDistinctMethod` (regression guard)
- `tests/Unit/WP_MockTest.php::testMultipleActionsAnyInstanceSameMethod` (any-instance path)
- `tests/Unit/WP_MockTest.php::testMultipleFiltersTypeSameMethod` (filter path)
- `tests/Unit/WP_Mock/HookTest.php::testTypeSafeOffsetIsStableAcrossMultipleTypeCalls` (key stability)

Run locally with PHP 8.3:

```bash
composer install
vendor/bin/phpunit --filter 'MultipleActionsType|MultipleFiltersType|TypeSafeOffsetIsStable'
vendor/bin/phpunit
vendor/bin/phpstan --memory-limit=512M
vendor/bin/phpcs
```

Results: 195 PHPUnit tests pass (one pre-existing skip in `TestCaseTest::testCanRunTests`), PHPStan clean, PHPCS clean.

Note: `composer test:behat` currently fails on trunk with a pre-existing parse error in `features/bootstrap/FunctionsContext.php`. That is unrelated to this change and is not introduced here.

### Reviewer checklist

- [ ] Code changes review
- [ ] Documentation changes review
- [ ] Unit tests pass
- [ ] Static analysis passes