### PR TITLE
fix(phpcs): exclude vendor/ from ruleset to silence third-party errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+- Exclude `vendor/` from the PHPCS ruleset so PHPCompatibility no longer reports issues in third-party dependencies (`nikic/php-parser`, `hamcrest/hamcrest-php`) on PHP 8.2+
+- Switch `testVersion` in the PHPCS ruleset from exact `7.4` to open range `7.4-` so the standard targets the minimum supported PHP and above
+
 ## [1.1.1](https://github.com/10up/wp_mock/compare/1.1.0...1.1.1) - 2025-12-03
 ### Fixed
 - Address PHP deprecation warnings about implicitly nullable parameters

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0"?>
 <ruleset name="Custom ruleset">
+	<description>WP_Mock PHPCS ruleset. Scans project source only; vendor/ is excluded so third-party code is never reported.</description>
 	<file>./php</file>
 	<file>./tests</file>
+	<exclude-pattern>*/vendor/*</exclude-pattern>
 	<arg value="sp"/>
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="7.4"/>
+	<config name="testVersion" value="7.4-"/>
 </ruleset>


### PR DESCRIPTION
## Summary

Fixes #251.

Running phpcs in the repo currently reports errors in third-party dependencies (`nikic/php-parser`, `hamcrest/hamcrest-php`) on PHP 8.2+. Those libraries are transitive dependencies pinned by other dev packages, and the project does not own their source.

This PR hardens the phpcs.xml ruleset so vendor is never scanned regardless of how phpcs is invoked, and switches `testVersion` from exact `7.4` to the open range `7.4-` so the standard targets the minimum supported PHP and above.

## Changes

### phpcs.xml

**Before:**
```xml
<ruleset name="Custom ruleset">
    <file>./php</file>
    <file>./tests</file>
    <arg value="sp"/>
    <rule ref="PHPCompatibility"/>
    <config name="testVersion" value="7.4"/>
</ruleset>
```

**After:**
```xml
<ruleset name="Custom ruleset">
    <description>WP_Mock PHPCS ruleset. Scans project source only; vendor/ is excluded so third-party code is never reported.</description>
    <file>./php</file>
    <file>./tests</file>
    <exclude-pattern>*/vendor/*</exclude-pattern>
    <arg value="sp"/>
    <rule ref="PHPCompatibility"/>
    <config name="testVersion" value="7.4-"/>
</ruleset>
```

**Why:** The original ruleset only restricted scan paths. When phpcs is invoked with a path that includes vendor (or with the project root as a default), third-party code gets scanned and reported. Excluding vendor in the ruleset is the standard PHPCS idiom for "scan only project source". The open-range `testVersion` matches PHPCompatibility conventions (per their README example) and ensures the standard targets the minimum supported PHP and above.

## Testing

**Test 1: Default scan (the CI command)**
1. `composer install`
2. `vendor/bin/phpcs`

Result: 43 files scanned in `./php` and `./tests`, all clean. No vendor noise.

**Test 2: Scan project root with the project ruleset**
1. `vendor/bin/phpcs .`

Result: 46 files scanned (43 above plus 3 config files in `.`), all clean. No vendor noise.

**Test 3: Reproduce the original report**
1. `vendor/bin/phpcs --runtime-set testVersion 8.2- .`

Result: only project files are scanned. No errors from `vendor/nikic/php-parser` or `vendor/hamcrest/hamcrest-php`.

**Test 4: Full test suite**
1. `composer test:phpunit`

Result: 160 tests, 1 skipped (pre-existing final-class limitation on PHP 7.4, unrelated to this change).